### PR TITLE
chore: add migrate script, .env.example, and top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# CareSync AI
+
+A POC healthcare sync app built with an Express + SQLite backend and a Vite + React frontend, communicating with a HAPI FHIR R4 server.
+
+## Prerequisites
+
+- Node.js (v18+)
+- Docker (for the optional HAPI FHIR server)
+
+## Setup
+
+```bash
+npm install
+```
+
+## Running the app
+
+### Both frontend and backend together
+
+```bash
+npm run dev
+```
+
+### Separately
+
+**Backend (Express API)** — runs on `http://localhost:4000`
+
+```bash
+npm run dev --workspace apps/api
+```
+
+**Frontend (Vite + React)** — runs on `http://localhost:5173`
+
+```bash
+npm run dev --workspace apps/web
+```
+
+### HAPI FHIR server (optional)
+
+The API expects a FHIR server at `http://localhost:8080/fhir` (override with `FHIR_BASE_URL`). To start it:
+
+```bash
+npm run fhir:up        # docker compose up -d hapi-fhir
+npm run fhir:import    # seed/import FHIR data
+```
+
+## Ports
+
+| Service    | URL                          |
+|------------|------------------------------|
+| Frontend   | `http://localhost:5173`      |
+| Backend    | `http://localhost:4000`      |
+| HAPI FHIR  | `http://localhost:8080/fhir` |
+
+## Other commands
+
+| Command              | Description                          |
+|----------------------|--------------------------------------|
+| `npm run build`      | Build both api and web               |
+| `npm run lint`       | Lint both api and web                |
+| `npm run test:api`   | Run backend tests                    |
+| `npm run test:web`   | Run frontend tests                   |
+| `npm run test:e2e`   | Run Playwright E2E tests             |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,19 @@
+# ── Database ──────────────────────────────────────────────
+# Path to the SQLite database file (default: apps/api/data/caresync.sqlite)
+# DB_PATH=./data/caresync.sqlite
+
+# ── API Server ────────────────────────────────────────────
+# Port the Express API listens on (default: 4000)
+# PORT=4000
+
+# ── FHIR ──────────────────────────────────────────────────
+# HAPI FHIR server base URL (default: http://localhost:8080/fhir)
+# FHIR_BASE_URL=http://localhost:8080/fhir
+
+# ── SMART on FHIR ─────────────────────────────────────────
+# SMART token endpoint (default: http://localhost:${PORT}/smart/token)
+# SMART_TOKEN_ENDPOINT=http://localhost:4000/smart/token
+
+# ── Auth / JWT ────────────────────────────────────────────
+# Secret used to sign JWT tokens (default: caresync-dev-secret-do-not-use-in-production)
+# JWT_SECRET=caresync-dev-secret-do-not-use-in-production

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "lint": "eslint src",
     "import": "tsx src/scripts/import-fhir.ts",
-    "seed": "tsx src/scripts/seed.ts"
+    "migrate": "tsx src/scripts/migrate.ts",
+    "seed": "tsx src/db/seed.ts"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/apps/api/src/scripts/migrate.ts
+++ b/apps/api/src/scripts/migrate.ts
@@ -1,0 +1,6 @@
+import { getDb } from '../db';
+
+if (require.main === module) {
+  getDb();
+  console.log('Migrations applied successfully.');
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "scripts": {
+"scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "oxlint",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:web": "npm run test --workspace apps/web",
     "test:e2e": "npm run test:e2e --workspace apps/web",
     "fhir:up": "docker compose up -d hapi-fhir",
-    "fhir:import": "npm run import --workspace apps/api"
+    "fhir:import": "npm run import --workspace apps/api",
+    "migrate": "npm run migrate --workspace apps/api",
+    "seed": "npm run seed --workspace apps/api"
   }
 }


### PR DESCRIPTION
## Summary
- Standalone `migrate` CLI (thin wrapper around the existing `getDb()` schema setup) plus root `migrate`/`seed` scripts so the DB can be initialized without booting the API.
- `.env.example` documenting the API's optional env vars (DB_PATH, PORT, FHIR_BASE_URL, SMART_TOKEN_ENDPOINT, JWT_SECRET).
- Top-level `README.md` covering setup and running both apps.

## Test plan
- [x] `npm run migrate` creates the SQLite schema (users, audit_log) via the existing `getDb()`/`migrate()` path
- [x] No behavior change to existing API/web code — docs and a CLI wrapper only

🤖 Generated with [Claude Code](https://claude.com/claude-code)