### PR TITLE
feat(S2): single-agent analysis with citation enforcement

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,3 +17,7 @@
 # ── Auth / JWT ────────────────────────────────────────────
 # Secret used to sign JWT tokens (default: caresync-dev-secret-do-not-use-in-production)
 # JWT_SECRET=caresync-dev-secret-do-not-use-in-production
+
+# ── OpenAI (agent analysis) ────────────────────────────────
+# API key for OpenAI gpt-5.5 agent runs. Unset disables live analysis.
+OPENAI_API_KEY=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,8 +35,8 @@
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.11.1",
     "cors": "^2.8.6",
-    "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "^9.0.3",
+    "openai": "^6.45.0"
   }
 }

--- a/apps/api/src/agents/citationValidator.test.ts
+++ b/apps/api/src/agents/citationValidator.test.ts
@@ -1,0 +1,105 @@
+import { validateCitations, redactUnvalidatedCitations, createNarrationBuffer } from './citationValidator';
+
+describe('validateCitations (Seam 2 — GD11 citation enforcement)', () => {
+  const validIds = new Set(['Condition/maria-chen-chf', 'Observation/maria-chen-hba1c']);
+
+  it('keeps an in-bundle citation and drops a fabricated one', () => {
+    const flags = [
+      { text: 'CHF diagnosis', fhirResourceId: 'Condition/maria-chen-chf' },
+      { text: 'hallucinated finding', fhirResourceId: 'Observation/does-not-exist' },
+    ];
+
+    const { valid, dropped } = validateCitations(flags, validIds);
+
+    expect(valid).toEqual([{ text: 'CHF diagnosis', fhirResourceId: 'Condition/maria-chen-chf' }]);
+    expect(dropped).toEqual([{ text: 'hallucinated finding', fhirResourceId: 'Observation/does-not-exist' }]);
+  });
+
+  it('returns empty valid and dropped for empty flags', () => {
+    expect(validateCitations([], validIds)).toEqual({ valid: [], dropped: [] });
+  });
+
+  it('resolves a whitespace-padded id (trims before matching)', () => {
+    const flags = [{ text: 'HbA1c elevated', fhirResourceId: '  Observation/maria-chen-hba1c  ' }];
+
+    const { valid, dropped } = validateCitations(flags, validIds);
+
+    expect(valid).toEqual([{ text: 'HbA1c elevated', fhirResourceId: 'Observation/maria-chen-hba1c' }]);
+    expect(dropped).toEqual([]);
+  });
+
+  it('does not case-fold FHIR ids (they are case-sensitive)', () => {
+    const flags = [{ text: 'wrong case', fhirResourceId: 'condition/maria-chen-chf' }];
+
+    const { valid, dropped } = validateCitations(flags, validIds);
+
+    expect(valid).toEqual([]);
+    expect(dropped).toEqual([{ text: 'wrong case', fhirResourceId: 'condition/maria-chen-chf' }]);
+  });
+});
+
+describe('redactUnvalidatedCitations (GD11 — narration text is not exempt from validation)', () => {
+  const validIds = new Set(['Condition/maria-chen-chf', 'Observation/maria-chen-hba1c']);
+
+  it('leaves a citation to an in-bundle resource untouched', () => {
+    const text = 'Given the CHF diagnosis (Condition/maria-chen-chf), risk is elevated.';
+    expect(redactUnvalidatedCitations(text, validIds)).toBe(text);
+  });
+
+  it('redacts a citation to a resource absent from the bundle', () => {
+    const text = 'Notably, Observation/does-not-exist supports this finding.';
+    expect(redactUnvalidatedCitations(text, validIds)).toBe('Notably, [unverified citation removed] supports this finding.');
+  });
+
+  it('leaves plain narration with no ResourceType/id pattern untouched', () => {
+    const text = 'This patient has a high readmission risk given recent labs.';
+    expect(redactUnvalidatedCitations(text, validIds)).toBe(text);
+  });
+
+  it('redacts multiple fabricated citations independently, keeping valid ones', () => {
+    const text = 'See Condition/maria-chen-chf and MedicationRequest/fake-one and also Task/fake-two.';
+    expect(redactUnvalidatedCitations(text, validIds)).toBe(
+      'See Condition/maria-chen-chf and [unverified citation removed] and also [unverified citation removed].'
+    );
+  });
+});
+
+describe('createNarrationBuffer (GD11 — streamed narration is buffered and redacted before emit)', () => {
+  const validIds = new Set(['Condition/maria-chen-chf']);
+
+  it('buffers short deltas and only redacts/emits once the lookahead window fills', () => {
+    const buffer = createNarrationBuffer(validIds, 10);
+
+    expect(buffer.push('short')).toBe('');
+    expect(buffer.flush()).toBe('short');
+  });
+
+  it('emits safe text once the pending buffer exceeds the lookahead, holding back the tail', () => {
+    const buffer = createNarrationBuffer(validIds, 5);
+
+    const emitted = buffer.push('hello world');
+
+    expect(emitted).toBe('hello ');
+    expect(buffer.flush()).toBe('world');
+  });
+
+  it('catches a fabricated citation even when its characters arrive split across two deltas', () => {
+    const buffer = createNarrationBuffer(validIds, 40);
+
+    let emitted = buffer.push('Notably, Observation/does-not-e');
+    emitted += buffer.push('xist supports this finding, plus more reasoning after it.');
+    emitted += buffer.flush();
+
+    expect(emitted).not.toContain('does-not-exist');
+    expect(emitted).toBe('Notably, [unverified citation removed] supports this finding, plus more reasoning after it.');
+  });
+
+  it('passes an in-bundle citation through unredacted end to end', () => {
+    const buffer = createNarrationBuffer(validIds, 20);
+
+    let emitted = buffer.push('CHF diagnosis (Condition/maria-chen-chf) drives this.');
+    emitted += buffer.flush();
+
+    expect(emitted).toBe('CHF diagnosis (Condition/maria-chen-chf) drives this.');
+  });
+});

--- a/apps/api/src/agents/citationValidator.ts
+++ b/apps/api/src/agents/citationValidator.ts
@@ -1,0 +1,93 @@
+export interface AgentFlag {
+  text: string;
+  fhirResourceId: string;
+}
+
+export interface CitationValidationResult {
+  valid: AgentFlag[];
+  dropped: AgentFlag[];
+}
+
+/**
+ * Seam 2 — GD11 citation enforcement. Pure, no I/O.
+ *
+ * Partitions agent flags into those whose `fhirResourceId` is present in the
+ * retrieved bundle (`validIds`, a set of `ResourceType/id` strings) and those
+ * that are not (hallucinated / out-of-bundle). The `fhirResourceId` is trimmed
+ * of surrounding whitespace before matching; FHIR ids are case-sensitive, so no
+ * case-folding is applied. Valid flags are returned with the trimmed id.
+ */
+export function validateCitations(flags: AgentFlag[], validIds: Set<string>): CitationValidationResult {
+  const valid: AgentFlag[] = [];
+  const dropped: AgentFlag[] = [];
+
+  for (const flag of flags) {
+    const trimmedId = flag.fhirResourceId.trim();
+    if (validIds.has(trimmedId)) {
+      valid.push({ ...flag, fhirResourceId: trimmedId });
+    } else {
+      dropped.push(flag);
+    }
+  }
+
+  return { valid, dropped };
+}
+
+const CITATION_PATTERN = /\b[A-Z][A-Za-z]*\/[A-Za-z0-9][A-Za-z0-9._-]*\b/g;
+
+/**
+ * GD11 also covers the agent's free-text narration, not just the structured
+ * `flags` array — a `ResourceType/id` mentioned in prose is just as much a
+ * citation as one in a flag. Replaces any such mention absent from the
+ * bundle with a visible placeholder; leaves everything else untouched.
+ */
+export function redactUnvalidatedCitations(text: string, validIds: Set<string>): string {
+  return text.replace(CITATION_PATTERN, (match) => (validIds.has(match) ? match : '[unverified citation removed]'));
+}
+
+export interface NarrationBuffer {
+  push(delta: string): string;
+  flush(): string;
+}
+
+/**
+ * Holds back the last `lookahead` characters of streamed narration so a
+ * `ResourceType/id` pattern split across two token deltas is still whole by
+ * the time it's checked, then redacts before releasing. Trades a small,
+ * bounded delay in the live-streaming effect for a real enforcement
+ * guarantee, instead of buffering the whole narration (which would lose the
+ * streaming effect entirely).
+ */
+const TOKEN_CHAR = /[A-Za-z0-9._/-]/;
+
+function isTokenChar(ch: string | undefined): boolean {
+  return ch !== undefined && TOKEN_CHAR.test(ch);
+}
+
+export function createNarrationBuffer(validIds: Set<string>, lookahead = 96): NarrationBuffer {
+  let pending = '';
+
+  return {
+    push(delta: string): string {
+      pending += delta;
+      if (pending.length <= lookahead) {
+        return '';
+      }
+      // Never cut inside a contiguous run of id-shaped characters — back off
+      // to the nearest boundary so a citation can't be split between the
+      // emitted "safe" text and what's still pending.
+      let cut = pending.length - lookahead;
+      while (cut > 0 && isTokenChar(pending[cut - 1]) && isTokenChar(pending[cut])) {
+        cut--;
+      }
+      const safeText = pending.slice(0, cut);
+      pending = pending.slice(cut);
+      return redactUnvalidatedCitations(safeText, validIds);
+    },
+    flush(): string {
+      const rest = redactUnvalidatedCitations(pending, validIds);
+      pending = '';
+      return rest;
+    },
+  };
+}

--- a/apps/api/src/agents/riskAgent.test.ts
+++ b/apps/api/src/agents/riskAgent.test.ts
@@ -1,0 +1,128 @@
+import { runRiskAgent, AgentEvent, RiskOutput } from './riskAgent';
+
+describe('OpenAI client construction is lazy (boot-time safety)', () => {
+  const originalKey = process.env.OPENAI_API_KEY;
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalKey;
+    }
+  });
+
+  it('importing the module does not throw when OPENAI_API_KEY is unset', async () => {
+    delete process.env.OPENAI_API_KEY;
+    // If this constructs the OpenAI client eagerly at import time, it throws
+    // here and fails the test — no assertion needed beyond letting it run.
+    await jest.isolateModulesAsync(async () => {
+      await import('./riskAgent');
+    });
+  });
+
+  it('only throws once the agent is actually invoked without an explicit client', async () => {
+    delete process.env.OPENAI_API_KEY;
+    let freshRunRiskAgent!: typeof runRiskAgent;
+    await jest.isolateModulesAsync(async () => {
+      const fresh = await import('./riskAgent');
+      freshRunRiskAgent = fresh.runRiskAgent;
+    });
+
+    const bundle = { resources: [], validIds: new Set<string>() };
+    await expect(async () => {
+      for await (const _event of freshRunRiskAgent(bundle)) {
+        // drain
+      }
+    }).rejects.toThrow();
+  });
+});
+
+// Fake OpenAI client — no network. Mimics the real SDK's `responses.create()`
+// contract closely enough to unit-test the agent: a `stream: true` call
+// returns an object that is async-iterable over typed Responses API events,
+// narration via `response.output_text.delta` and the structured result via
+// the final `response.completed` event's `.response.output` array.
+function fakeStream(textDeltas: string[], finalOutput: any[]) {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      for (const text of textDeltas) {
+        yield { type: 'response.output_text.delta', delta: text };
+      }
+      yield { type: 'response.completed', response: { output: finalOutput } };
+    },
+  };
+}
+
+describe('runRiskAgent (B1 revised — mocked OpenAI client, no live call)', () => {
+  const bundle = {
+    resources: [
+      { resourceType: 'Condition', id: 'maria-chen-chf' },
+      { resourceType: 'Observation', id: 'maria-chen-bnp' },
+    ],
+    validIds: new Set(['Condition/maria-chen-chf', 'Observation/maria-chen-bnp']),
+  };
+
+  it('yields token events for streamed text, then a final result event with the parsed RiskOutput', async () => {
+    const output: RiskOutput = {
+      riskScore: 87,
+      riskLevel: 'critical',
+      flags: [{ text: 'Elevated BNP consistent with CHF exacerbation', fhirResourceId: 'Observation/maria-chen-bnp' }],
+      readmissionProbability: 0.62,
+    };
+    const createFn = jest.fn().mockResolvedValue(
+      fakeStream(
+        ['Analyzing recent labs', ' and active conditions...'],
+        [{ type: 'function_call', call_id: 'call_1', name: 'report_risk', arguments: JSON.stringify(output) }]
+      )
+    );
+    const fakeClient = { responses: { create: createFn } } as any;
+
+    const events: AgentEvent[] = [];
+    for await (const event of runRiskAgent(bundle, fakeClient)) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: 'token', text: 'Analyzing recent labs' },
+      { type: 'token', text: ' and active conditions...' },
+      { type: 'result', output },
+    ]);
+  });
+
+  it('calls the client with gpt-5.5, streaming, and a report_risk tool', async () => {
+    const createFn = jest.fn().mockResolvedValue(
+      fakeStream([], [
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'report_risk',
+          arguments: JSON.stringify({ riskScore: 10, riskLevel: 'low', flags: [], readmissionProbability: 0.1 }),
+        },
+      ])
+    );
+    const fakeClient = { responses: { create: createFn } } as any;
+
+    for await (const _event of runRiskAgent(bundle, fakeClient)) {
+      // drain
+    }
+
+    expect(createFn).toHaveBeenCalledTimes(1);
+    const params = createFn.mock.calls[0][0];
+    expect(params.model).toBe('gpt-5.5');
+    expect(params.stream).toBe(true);
+    expect(params.tools).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'function', name: 'report_risk' })])
+    );
+  });
+
+  it('throws if the model never calls report_risk', async () => {
+    const createFn = jest.fn().mockResolvedValue(fakeStream(['no tool use here'], []));
+    const fakeClient = { responses: { create: createFn } } as any;
+
+    await expect(async () => {
+      for await (const _event of runRiskAgent(bundle, fakeClient)) {
+        // drain
+      }
+    }).rejects.toThrow();
+  });
+});

--- a/apps/api/src/agents/riskAgent.ts
+++ b/apps/api/src/agents/riskAgent.ts
@@ -1,0 +1,123 @@
+import OpenAI from 'openai';
+import { PatientBundle } from '../fhir/client';
+import { AgentFlag } from './citationValidator';
+
+// Agent model is OpenAI gpt-5.5 (GD13, revised 2026-07-04 — see plan.md).
+export const MODEL = 'gpt-5.5';
+
+// The SDK client is the abstraction (GD13 / plan A1 — no factory module).
+// Built lazily, on first use, not at module import time: `new OpenAI()`
+// throws synchronously if OPENAI_API_KEY is unset, and this module is
+// imported unconditionally at API boot (via routes/analysis.ts) — an eager
+// `const openai = new OpenAI()` here would crash the whole process on
+// startup whenever the key is missing, instead of failing only the one
+// request that needs it (see implementation-plan.md Iteration 2 rollback
+// note).
+let cachedClient: OpenAI | undefined;
+
+function getOpenAiClient(): OpenAI {
+  if (!cachedClient) {
+    cachedClient = new OpenAI();
+  }
+  return cachedClient;
+}
+
+export interface RiskOutput {
+  riskScore: number;
+  riskLevel: 'low' | 'moderate' | 'high' | 'critical';
+  flags: AgentFlag[];
+  readmissionProbability: number;
+}
+
+export type AgentEvent = { type: 'token'; text: string } | { type: 'result'; output: RiskOutput };
+
+// Structured-output contract (GD11): the agent must report through this tool
+// rather than free text, and every flag must cite a `ResourceType/id` that
+// exists in the bundle it was given (enforced downstream by the citation
+// validator — this schema just shapes the model's output). Responses API
+// function tools are flat (not nested under `function` like Chat Completions).
+const REPORT_RISK_TOOL = {
+  type: 'function' as const,
+  name: 'report_risk',
+  description:
+    'Report the structured 30-day readmission risk assessment for this patient. Call this exactly once, after narrating your reasoning.',
+  strict: false,
+  parameters: {
+    type: 'object' as const,
+    properties: {
+      riskScore: { type: 'number', description: 'Overall readmission risk score, 0-100.' },
+      riskLevel: { type: 'string', enum: ['low', 'moderate', 'high', 'critical'] },
+      flags: {
+        type: 'array',
+        description: 'Clinical findings driving the risk score.',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'Human-readable finding.' },
+            fhirResourceId: {
+              type: 'string',
+              description:
+                'The exact "ResourceType/id" of the FHIR resource that supports this finding. Must be one of the ids provided in the prompt — never invent one.',
+            },
+          },
+          required: ['text', 'fhirResourceId'],
+        },
+      },
+      readmissionProbability: { type: 'number', description: '30-day readmission probability, 0-1.' },
+    },
+    required: ['riskScore', 'riskLevel', 'flags', 'readmissionProbability'],
+  },
+};
+
+function buildPrompt(bundle: PatientBundle): string {
+  const resourceLines = bundle.resources.map((r) => `- ${r.resourceType}/${r.id}: ${JSON.stringify(r)}`).join('\n');
+
+  return [
+    'You are a clinical risk-assessment agent. Narrate your reasoning briefly in plain text, then report your findings by calling the report_risk tool exactly once.',
+    '',
+    "You are the Risk agent on a care-coordination platform, assessing 30-day hospital readmission risk.",
+    "Below is the patient's complete retrieved FHIR record (one resource per line, as `ResourceType/id: <resource JSON>`).",
+    '',
+    resourceLines,
+    '',
+    'Every flag you report MUST cite the exact `ResourceType/id` of a resource listed above via `fhirResourceId`.',
+    'Never cite a resource id that is not listed above — fabricated citations are dropped and undermine clinical trust.',
+    'Briefly narrate your clinical reasoning, then call the `report_risk` tool exactly once with the structured result.',
+  ].join('\n');
+}
+
+/**
+ * Runs the Risk agent over a patient's FHIR bundle on OpenAI gpt-5.5 (GD13,
+ * revised 2026-07-04), streaming narrated reasoning as `token` events and
+ * finishing with a single `result` event carrying the structured
+ * `RiskOutput` (obtained via the `report_risk` function tool, parsed from
+ * the finalized `response.completed` event's output array).
+ *
+ * `client` defaults to the lazily-constructed OpenAI client so tests can
+ * inject a fake and avoid any live network/API call (and avoid ever
+ * constructing the real client at all).
+ */
+export async function* runRiskAgent(bundle: PatientBundle, client = getOpenAiClient()): AsyncIterable<AgentEvent> {
+  const stream = await client.responses.create({
+    model: MODEL,
+    input: buildPrompt(bundle),
+    tools: [REPORT_RISK_TOOL],
+    stream: true,
+  });
+
+  let toolCall: { name: string; arguments: string } | undefined;
+
+  for await (const event of stream as any) {
+    if (event.type === 'response.output_text.delta') {
+      yield { type: 'token', text: event.delta };
+    } else if (event.type === 'response.completed') {
+      toolCall = event.response.output.find((item: any) => item.type === 'function_call' && item.name === 'report_risk');
+    }
+  }
+
+  if (!toolCall) {
+    throw new Error('Risk agent did not call report_risk with a structured result');
+  }
+
+  yield { type: 'result', output: JSON.parse(toolCall.arguments) };
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,14 @@
+// ponytail: Node 22 loads .env natively — no dotenv dependency needed.
+// Nothing else loaded .env, so `new OpenAI()` (constructed at import time in
+// riskAgent.ts) would throw on a fresh shell even with the key on disk.
+// Try apps/api/.env, then fall back to the repo-root .env (where
+// OPENAI_API_KEY currently lives); loadEnvFile never overrides vars already
+// set (an exported key or the jest.setup placeholder still wins). MUST be
+// imported first in index.ts — before the risk agent's `new OpenAI()` runs.
+for (const path of ['.env', '../../.env']) {
+  try {
+    process.loadEnvFile(path);
+  } catch {
+    // missing file — try the next candidate
+  }
+}

--- a/apps/api/src/fhir/client.test.ts
+++ b/apps/api/src/fhir/client.test.ts
@@ -71,6 +71,51 @@ describe('FhirReadService', () => {
     expect(maria!.conditionTags.length).toBeLessThanOrEqual(2);
     expect(panel.length).toBeGreaterThanOrEqual(6);
   });
+
+  describe('getPatientBundle ($everything — GD11 citation source)', () => {
+    it("returns Maria's full record including her Conditions and Observations", async () => {
+      const { resources } = await service.getPatientBundle(coordinator, 'maria-chen');
+
+      const types = resources.map((r) => r.resourceType);
+      expect(types).toEqual(expect.arrayContaining(['Patient', 'Condition', 'Observation']));
+      expect(types.filter((t) => t === 'Condition').length).toBeGreaterThanOrEqual(1);
+      expect(types.filter((t) => t === 'Observation').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('derives validIds as one ResourceType/id per returned resource, including Patient/maria-chen', async () => {
+      const { resources, validIds } = await service.getPatientBundle(coordinator, 'maria-chen');
+
+      expect(validIds.size).toBe(resources.length);
+      expect(validIds.has('Patient/maria-chen')).toBe(true);
+      for (const r of resources) {
+        expect(validIds.has(`${r.resourceType}/${r.id}`)).toBe(true);
+      }
+    });
+
+    it('writes one success audit row for the bundle read', async () => {
+      await service.getPatientBundle(coordinator, 'maria-chen');
+
+      const rows = db.prepare('SELECT * FROM audit_log ORDER BY id').all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        actor: 'coord-1',
+        outcome: 'success',
+        fhir_resource: 'Patient/maria-chen/$everything',
+      });
+    });
+
+    it('denies a Social Worker (no clinical scope) and writes a denied audit row', async () => {
+      await expect(service.getPatientBundle(socialWorker, 'maria-chen')).rejects.toBeInstanceOf(ScopeDeniedError);
+
+      const rows = db.prepare('SELECT * FROM audit_log ORDER BY id').all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        actor: 'sw-1',
+        outcome: 'denied',
+        fhir_resource: 'Patient/maria-chen/$everything',
+      });
+    });
+  });
 });
 
 describe('FhirReadService with a SMART token client', () => {

--- a/apps/api/src/fhir/client.ts
+++ b/apps/api/src/fhir/client.ts
@@ -59,6 +59,11 @@ export interface PanelEntry {
   conditionTags: string[];
 }
 
+export interface PatientBundle {
+  resources: any[];
+  validIds: Set<string>;
+}
+
 interface FhirBundleEntry<T> {
   resource: T;
 }
@@ -136,6 +141,19 @@ export class FhirReadService {
       due: e.resource.restriction?.period?.end,
       status: FHIR_STATUS_TO_DISPLAY[e.resource.status] ?? 'Open',
     }));
+  }
+
+  async getPatientBundle(actor: AuthTokenPayload, patientId: string): Promise<PatientBundle> {
+    const resource = `Patient/${patientId}/$everything`;
+    this.guard(actor, 'clinical', resource);
+    const bundle = await this.fhirFetch<FhirBundle<any>>(`/${resource}`);
+    writeAudit(this.db, { actor: actor.id, action: 'read', fhirResource: resource, outcome: 'success' });
+
+    const resources = (bundle.entry ?? []).map((e) => e.resource);
+    // validIds is derived from resources — never assembled separately — so the
+    // agent's input and the citation-check set cannot drift (GD11).
+    const validIds = new Set(resources.map((r) => `${r.resourceType}/${r.id}`));
+    return { resources, validIds };
   }
 
   async getAssignedPanel(actor: AuthTokenPayload): Promise<PanelEntry[]> {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,8 +1,10 @@
+import './env'; // load .env before riskAgent.ts constructs `new OpenAI()`
 import express from 'express';
 import cors from 'cors';
 import { getDb } from './db';
 import { createAuthRouter } from './routes/auth';
 import { createPatientsRouter } from './routes/patients';
+import { createAnalysisRouter } from './routes/analysis';
 import { FhirReadService } from './fhir/client';
 import { generateKeyPair } from './smart/keys';
 import { createTokenServer } from './smart/tokenServer';
@@ -39,6 +41,9 @@ if (require.main === module) {
   const fhirService = new FhirReadService(db, FHIR_BASE_URL, tokenClient);
   app.use('/api/auth', createAuthRouter(db));
   app.use('/api/patients', createPatientsRouter(fhirService));
+  // S2 — a second router on the same base path; the real runRiskAgent is the
+  // default so no extra wiring is needed beyond mounting this route.
+  app.use('/api/patients', createAnalysisRouter(fhirService));
 
   app.listen(PORT, () => {
     console.log(`API listening on :${PORT}`);

--- a/apps/api/src/routes/analysis.test.ts
+++ b/apps/api/src/routes/analysis.test.ts
@@ -1,0 +1,173 @@
+import express from 'express';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import { migrate } from '../db';
+import { seedDemoUsers, DEMO_PASSWORD } from '../db/seed';
+import { createAuthRouter } from './auth';
+import { createAnalysisRouter } from './analysis';
+import { FhirReadService } from '../fhir/client';
+import { AgentEvent, RiskOutput } from '../agents/riskAgent';
+
+// Stub agent (S2 acceptance) — no live OpenAI call. Yields one token then a
+// result with one in-bundle citation and one fabricated citation, so the
+// route's GD11 validation gate (Seam 2) has something real to drop.
+async function* stubAgent(): AsyncIterable<AgentEvent> {
+  yield { type: 'token', text: 'Reviewing chart...' };
+  const output: RiskOutput = {
+    riskScore: 87,
+    riskLevel: 'critical',
+    flags: [
+      { text: 'CHF diagnosis drives elevated readmission risk', fhirResourceId: 'Condition/maria-chen-chf' },
+      { text: 'hallucinated finding', fhirResourceId: 'Condition/does-not-exist' },
+    ],
+    readmissionProbability: 0.7,
+  };
+  yield { type: 'result', output };
+}
+
+function buildApp(db: Database.Database) {
+  const app = express();
+  app.use(express.json());
+  const fhirService = new FhirReadService(db, process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir');
+  app.use('/api/auth', createAuthRouter(db));
+  app.use('/api/patients', createAnalysisRouter(fhirService, stubAgent));
+  return app;
+}
+
+async function loginAs(app: express.Express, email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: DEMO_PASSWORD });
+  return res.body.token;
+}
+
+interface SseEvent {
+  event: string;
+  data: any;
+}
+
+function parseSse(body: string): SseEvent[] {
+  return body
+    .split('\n\n')
+    .map((chunk) => chunk.trim())
+    .filter((chunk) => chunk.length > 0)
+    .map((chunk) => {
+      const lines = chunk.split('\n');
+      const eventLine = lines.find((l) => l.startsWith('event: '));
+      const dataLine = lines.find((l) => l.startsWith('data: '));
+      if (!eventLine || !dataLine) {
+        throw new Error(`Malformed SSE chunk: ${chunk}`);
+      }
+      return { event: eventLine.slice('event: '.length), data: JSON.parse(dataLine.slice('data: '.length)) };
+    });
+}
+
+async function* throwingAgent(): AsyncIterable<AgentEvent> {
+  yield { type: 'token', text: 'Reviewing the full chart in detail before reaching any conclusion at all here...' };
+  throw new Error('OpenAI request failed');
+}
+
+async function* narrationWithFabricatedCitationAgent(): AsyncIterable<AgentEvent> {
+  yield { type: 'token', text: 'Notably, Observation/does-not-exist supports this, and Condition/maria-chen-chf too.' };
+  const output: RiskOutput = {
+    riskScore: 40,
+    riskLevel: 'moderate',
+    flags: [],
+    readmissionProbability: 0.3,
+  };
+  yield { type: 'result', output };
+}
+
+describe('analysis routes (B2 — SSE stream + citation validation gate, GD11)', () => {
+  let db: Database.Database;
+  let app: express.Express;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    seedDemoUsers(db);
+    app = buildApp(db);
+  });
+
+  it('streams the token, emits only the valid finding, drops the fabricated citation, and audits the read', async () => {
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+
+    const res = await request(app).post('/api/patients/maria-chen/analysis').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+
+    const events = parseSse(res.text);
+
+    const tokenEvents = events.filter((e) => e.event === 'token');
+    expect(tokenEvents).toEqual([{ event: 'token', data: { text: 'Reviewing chart...' } }]);
+
+    const findingEvents = events.filter((e) => e.event === 'finding');
+    expect(findingEvents).toHaveLength(1);
+    expect(findingEvents[0].data).toMatchObject({ fhirResourceId: 'Condition/maria-chen-chf' });
+
+    // The fabricated citation never reaches the client, in any event payload.
+    expect(res.text).not.toContain('does-not-exist');
+
+    const completeEvent = events.find((e) => e.event === 'complete');
+    expect(completeEvent).toBeDefined();
+    expect(completeEvent!.data).toMatchObject({
+      riskScore: 87,
+      riskLevel: 'critical',
+      readmissionProbability: 0.7,
+      findingCount: 1,
+      droppedCount: 1,
+    });
+
+    const rows = db.prepare('SELECT * FROM audit_log ORDER BY id').all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      actor: expect.any(String),
+      outcome: 'success',
+      fhir_resource: 'Patient/maria-chen/$everything',
+    });
+  });
+
+  it('emits an error event and ends the stream cleanly if the agent throws mid-stream', async () => {
+    const app = express();
+    app.use(express.json());
+    const fhirService = new FhirReadService(db, process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir');
+    app.use('/api/auth', createAuthRouter(db));
+    app.use('/api/patients', createAnalysisRouter(fhirService, throwingAgent));
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+
+    const res = await request(app).post('/api/patients/maria-chen/analysis').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(events.find((e) => e.event === 'complete')).toBeUndefined();
+  });
+
+  it('redacts a fabricated citation mentioned in the narration stream, not just in structured flags', async () => {
+    const app = express();
+    app.use(express.json());
+    const fhirService = new FhirReadService(db, process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir');
+    app.use('/api/auth', createAuthRouter(db));
+    app.use('/api/patients', createAnalysisRouter(fhirService, narrationWithFabricatedCitationAgent));
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+
+    const res = await request(app).post('/api/patients/maria-chen/analysis').set('Authorization', `Bearer ${token}`);
+
+    expect(res.text).not.toContain('does-not-exist');
+    expect(res.text).toContain('Condition/maria-chen-chf');
+    expect(res.text).toContain('[unverified citation removed]');
+  });
+
+  it('denies a Social Worker (no clinical scope) before streaming', async () => {
+    const token = await loginAs(app, 'socialworker@caresync.demo');
+
+    const res = await request(app).post('/api/patients/maria-chen/analysis').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/api/patients/maria-chen/analysis');
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/analysis.ts
+++ b/apps/api/src/routes/analysis.ts
@@ -1,0 +1,90 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth';
+import { FhirReadService, PatientBundle, ScopeDeniedError } from '../fhir/client';
+import { runRiskAgent, AgentEvent } from '../agents/riskAgent';
+import { validateCitations, createNarrationBuffer } from '../agents/citationValidator';
+
+type RunAgent = (bundle: PatientBundle) => AsyncIterable<AgentEvent>;
+
+function writeSseEvent(res: import('express').Response, event: string, data: unknown): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+/**
+ * S2 analysis route (B2). `POST /:id/analysis` audits + scope-guards one
+ * `$everything` read of the patient's bundle (via `FhirReadService`), then
+ * streams the Risk agent's output over SSE. Every flag's `fhirResourceId` is
+ * validated against the bundle's `validIds` (GD11 — Seam 2) before it is
+ * emitted as a `finding`; dropped citations never reach the client.
+ *
+ * `runAgent` defaults to the real `runRiskAgent` so production wiring needs
+ * no extra step, while tests inject a stub to avoid a live OpenAI call.
+ */
+export function createAnalysisRouter(fhirService: FhirReadService, runAgent: RunAgent = runRiskAgent): Router {
+  const router = Router();
+  router.use(requireAuth);
+
+  router.post('/:id/analysis', async (req, res) => {
+    let bundle: PatientBundle;
+    try {
+      bundle = await fhirService.getPatientBundle(req.auth!, req.params.id);
+    } catch (err) {
+      if (err instanceof ScopeDeniedError) {
+        res.status(403).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    // GD11 covers narration as well as structured flags — a fabricated
+    // ResourceType/id mentioned in prose is redacted before it reaches the
+    // client, same as a fabricated flag.
+    const narration = createNarrationBuffer(bundle.validIds);
+
+    try {
+      for await (const event of runAgent(bundle)) {
+        if (event.type === 'token') {
+          const safeText = narration.push(event.text);
+          if (safeText) {
+            writeSseEvent(res, 'token', { text: safeText });
+          }
+          continue;
+        }
+
+        const remainder = narration.flush();
+        if (remainder) {
+          writeSseEvent(res, 'token', { text: remainder });
+        }
+
+        // event.type === 'result' — the validation gate (GD11): no finding
+        // reaches the client citing a resource absent from the retrieved bundle.
+        const { valid, dropped } = validateCitations(event.output.flags, bundle.validIds);
+        for (const flag of valid) {
+          writeSseEvent(res, 'finding', flag);
+        }
+        writeSseEvent(res, 'complete', {
+          riskScore: event.output.riskScore,
+          riskLevel: event.output.riskLevel,
+          readmissionProbability: event.output.readmissionProbability,
+          findingCount: valid.length,
+          droppedCount: dropped.length,
+        });
+      }
+    } catch {
+      // The connection is already open (res.writeHead ran above) — an SSE
+      // error event is the only way left to tell the client the run failed;
+      // headers can't change to a 5xx status at this point.
+      writeSseEvent(res, 'error', { message: 'Analysis failed' });
+    }
+
+    res.end();
+  });
+
+  return router;
+}

--- a/apps/web/e2e/patient-analysis.spec.ts
+++ b/apps/web/e2e/patient-analysis.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * S2 D2 — Run Analysis / streaming Risk feed E2E.
+ *
+ * The idle-state and "Analyzing…" assertions exercise the real frontend
+ * against the real backend (no interception needed — they don't require a
+ * successful agent response).
+ *
+ * The full streaming/finding/citation-chip assertion intercepts the
+ * `POST /api/patients/:id/analysis` network call via Playwright's
+ * `page.route()` and serves a synthetic `text/event-stream` response in the
+ * exact SSE frame format the real route (`apps/api/src/routes/analysis.ts`)
+ * emits. This is a deliberate substitute for a live OpenAI call — there is
+ * no `OPENAI_API_KEY` configured in this environment, so a real "Run
+ * Analysis" click would hang/fail at the network step. Per CLAUDE.md's
+ * "Evidence boundaries", this proves the frontend's SSE-consumption and
+ * rendering logic end-to-end in a real headless browser (packaged UI / local
+ * mock strength) — it is NOT live-model-call proof, and it does not exercise
+ * the server-side citation validator (that's covered by the API-boundary
+ * Supertest in B2, and by D3's live run).
+ */
+test('Coordinator runs analysis on Maria Chen and sees the Risk feed stream', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('coordinator@caresync.demo');
+  await page.getByLabel('Password').fill('Demo1234!');
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\/panel$/);
+
+  await page.goto('/patients/maria-chen');
+  await expect(page.getByText('Maria Chen')).toBeVisible();
+
+  const runButton = page.getByRole('button', { name: /run analysis/i });
+  await expect(runButton).toBeVisible();
+
+  // Pre-click: all four feed boxes are honest idle placeholders — no live
+  // call has happened yet, so this needs no backend/network involvement.
+  const idlePlaceholders = page.getByText('Awaiting analysis run…');
+  await expect(idlePlaceholders).toHaveCount(4);
+
+  // Intercept the analysis SSE call with a synthetic response matching the
+  // real route's event format (`event: <type>\ndata: <json>\n\n`), using ids
+  // that are real on Maria's seeded record (apps/api/src/fhir-data/seed-patients.ts)
+  // so the citation chip looks like genuine data.
+  await page.route('**/api/patients/*/analysis', async (route) => {
+    // Small artificial delay so the "Analyzing…" in-flight state below is
+    // reliably observable rather than racing a near-instant fulfill.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const frames = [
+      ['token', { text: 'Elevated BNP and reduced eGFR ' }],
+      ['token', { text: 'are consistent with a CHF exacerbation risk.' }],
+      ['finding', { text: 'Elevated BNP consistent with CHF exacerbation', fhirResourceId: 'Observation/maria-chen-bnp' }],
+      ['complete', { riskScore: 87, riskLevel: 'high', readmissionProbability: 0.62, findingCount: 1, droppedCount: 1 }],
+    ] as const;
+    const body = frames.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join('');
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body,
+    });
+  });
+
+  await runButton.click();
+
+  // Streaming has started: the button flips to the "Analyzing…"/spinner state
+  // synchronously (running=true set before the fetch resolves) — no live call
+  // needed for this assertion either.
+  await expect(page.getByRole('button', { name: /analyzing/i })).toBeVisible();
+
+  // Once the (mocked) stream completes: narrated text, the validated finding's
+  // citation chip, and the summary line all render from real SSE parsing.
+  await expect(page.getByText(/Elevated BNP and reduced eGFR/)).toBeVisible();
+  await expect(page.getByText(/consistent with a CHF exacerbation risk/)).toBeVisible();
+  await expect(page.getByText('Observation/maria-chen-bnp')).toBeVisible();
+  await expect(page.getByTestId('risk-summary')).toHaveText(/high risk · score 87/i);
+
+  // The button returns to its resting state, and the other three feed boxes
+  // stay honest idle placeholders (not wired up until S3).
+  await expect(page.getByRole('button', { name: /^run analysis$/i })).toBeVisible();
+  await expect(idlePlaceholders).toHaveCount(3);
+});

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { streamAnalysis } from './client';
+
+/** Builds a ReadableStream<Uint8Array> that emits the given string chunks in order. */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+describe('streamAnalysis', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('caresync_token', 'header.payload.signature');
+  });
+
+  it('parses token, finding, and complete SSE events, including a frame split across chunks', async () => {
+    const frame1 = 'event: token\ndata: {"text":"Risk "}\n\n';
+    const frame2 = 'event: token\ndata: {"text":"is elevated."}\n\n';
+    const frame3 =
+      'event: finding\ndata: {"text":"HbA1c 8.9%","fhirResourceId":"Observation/hba1c-1"}\n\n';
+    const frame4 =
+      'event: complete\ndata: {"riskScore":87,"riskLevel":"high","readmissionProbability":0.42,"findingCount":1,"droppedCount":0}\n\n';
+
+    // Split frame3 across two chunks to prove buffering works across `read()` calls.
+    const splitPoint = Math.floor(frame3.length / 2);
+    const chunks = [frame1, frame2, frame3.slice(0, splitPoint), frame3.slice(splitPoint), frame4];
+
+    const body = sseStream(chunks);
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(body));
+
+    const onToken = vi.fn();
+    const onFinding = vi.fn();
+    const onComplete = vi.fn();
+
+    await streamAnalysis('maria-1', { onToken, onFinding, onComplete });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/patients/maria-1/analysis'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer header.payload.signature' }),
+      })
+    );
+
+    expect(onToken).toHaveBeenNthCalledWith(1, 'Risk ');
+    expect(onToken).toHaveBeenNthCalledWith(2, 'is elevated.');
+    expect(onFinding).toHaveBeenCalledWith({ text: 'HbA1c 8.9%', fhirResourceId: 'Observation/hba1c-1' });
+    expect(onComplete).toHaveBeenCalledWith({
+      riskScore: 87,
+      riskLevel: 'high',
+      readmissionProbability: 0.42,
+      findingCount: 1,
+      droppedCount: 0,
+    });
+
+    // Order: token, token, finding, complete
+    const tokenCallOrder = onToken.mock.invocationCallOrder;
+    const findingCallOrder = onFinding.mock.invocationCallOrder[0];
+    const completeCallOrder = onComplete.mock.invocationCallOrder[0];
+    expect(tokenCallOrder[0]).toBeLessThan(tokenCallOrder[1]);
+    expect(tokenCallOrder[1]).toBeLessThan(findingCallOrder);
+    expect(findingCallOrder).toBeLessThan(completeCallOrder);
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -53,3 +53,73 @@ export interface PatientDetail {
 export function getPatient(id: string): Promise<PatientDetail> {
   return apiFetch(`/api/patients/${id}`);
 }
+
+export interface AnalysisFinding {
+  text: string;
+  fhirResourceId: string;
+}
+
+export interface AnalysisSummary {
+  riskScore: number;
+  riskLevel: string;
+  readmissionProbability: number;
+  findingCount: number;
+  droppedCount: number;
+}
+
+export interface AnalysisHandlers {
+  onToken?: (text: string) => void;
+  onFinding?: (flag: AnalysisFinding) => void;
+  onComplete?: (summary: AnalysisSummary) => void;
+}
+
+/**
+ * Streams `POST /api/patients/:id/analysis`'s `text/event-stream` response,
+ * dispatching each SSE frame (`event: <type>\ndata: <json>\n\n`) to the
+ * matching handler as it arrives. Buffers across `read()` calls so a frame
+ * split across chunk boundaries is still parsed correctly.
+ */
+export async function streamAnalysis(patientId: string, handlers: AnalysisHandlers): Promise<void> {
+  const token = localStorage.getItem(TOKEN_KEY);
+  const res = await fetch(`${API_BASE_URL}/api/patients/${patientId}/analysis`, {
+    method: 'POST',
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok || !res.body) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(body.error ?? `Request failed: ${res.status}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const dispatch = (event: string, data: string) => {
+    const payload = JSON.parse(data);
+    if (event === 'token') handlers.onToken?.(payload.text);
+    else if (event === 'finding') handlers.onFinding?.(payload);
+    else if (event === 'complete') handlers.onComplete?.(payload);
+  };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let frameEnd: number;
+    while ((frameEnd = buffer.indexOf('\n\n')) !== -1) {
+      const frame = buffer.slice(0, frameEnd);
+      buffer = buffer.slice(frameEnd + 2);
+
+      let event = '';
+      let data = '';
+      for (const line of frame.split('\n')) {
+        if (line.startsWith('event: ')) event = line.slice('event: '.length);
+        else if (line.startsWith('data: ')) data = line.slice('data: '.length);
+      }
+      if (event && data) dispatch(event, data);
+    }
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13,6 +13,16 @@
   }
 }
 
+/* Blinking streaming cursor for .feed-text.streaming (reference-materials/caresync-ai.html). */
+@keyframes feed-blink {
+  50% {
+    opacity: 0;
+  }
+}
+.feed-cursor {
+  animation: feed-blink 0.9s steps(1) infinite;
+}
+
 /* Scanline overlay — subtle CRT/medical-display texture (HANDOFF §4). */
 .scanline-overlay {
   position: fixed;

--- a/apps/web/src/pages/PatientDetail.test.tsx
+++ b/apps/web/src/pages/PatientDetail.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PatientDetail } from './PatientDetail';
+import * as client from '../api/client';
+import type { AnalysisHandlers } from '../api/client';
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return { ...actual, getPatient: vi.fn(), streamAnalysis: vi.fn() };
+});
+
+const mockPatient = {
+  patient: { id: 'maria-1', name: 'Maria Chen', gender: 'female', birthDate: '1957-03-02' },
+  conditions: [{ id: 'cond-1', code: 'E11.9', display: 'Type 2 diabetes' }],
+  tasks: [],
+};
+
+function renderPatientDetail() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/patients/maria-1']}>
+        <Routes>
+          <Route path="/patients/:id" element={<PatientDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('PatientDetail — Run Analysis + Risk feed', () => {
+  beforeEach(() => {
+    vi.mocked(client.getPatient).mockResolvedValue(mockPatient);
+  });
+
+  it('shows all four feeds idle before any run', async () => {
+    renderPatientDetail();
+    await screen.findByText('Maria Chen');
+    expect(screen.getAllByText('Awaiting analysis run…')).toHaveLength(4);
+  });
+
+  it('streams Risk feed tokens incrementally, renders a finding chip and summary, and never touches the other three idle feeds', async () => {
+    let capturedHandlers: AnalysisHandlers | undefined;
+    let resolveStream: () => void = () => {};
+    vi.mocked(client.streamAnalysis).mockImplementation((_id, handlers) => {
+      capturedHandlers = handlers;
+      return new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    });
+
+    renderPatientDetail();
+    await screen.findByText('Maria Chen');
+
+    fireEvent.click(screen.getByRole('button', { name: /run analysis/i }));
+
+    expect(client.streamAnalysis).toHaveBeenCalledWith('maria-1', expect.any(Object));
+    expect(capturedHandlers).toBeDefined();
+
+    // Other three feeds stay idle the instant a run starts.
+    expect(screen.getAllByText('Awaiting analysis run…')).toHaveLength(3);
+
+    act(() => capturedHandlers!.onToken?.('Risk is '));
+    expect(screen.getByText('Risk is')).toBeInTheDocument();
+
+    act(() => capturedHandlers!.onToken?.('elevated.'));
+    expect(screen.getByText('Risk is elevated.')).toBeInTheDocument();
+
+    act(() =>
+      capturedHandlers!.onFinding?.({ text: 'HbA1c 8.9%', fhirResourceId: 'Observation/hba1c-1' })
+    );
+    expect(screen.getByText('Observation/hba1c-1')).toBeInTheDocument();
+
+    act(() => {
+      capturedHandlers!.onComplete?.({
+        riskScore: 87,
+        riskLevel: 'high',
+        readmissionProbability: 0.42,
+        findingCount: 1,
+        droppedCount: 0,
+      });
+      resolveStream();
+    });
+
+    const summary = await screen.findByTestId('risk-summary');
+    expect(summary.textContent).toContain('high');
+    expect(summary.textContent).toContain('87');
+
+    // Still idle throughout — the other three feeds were never wired up.
+    expect(screen.getAllByText('Awaiting analysis run…')).toHaveLength(3);
+  });
+});

--- a/apps/web/src/pages/PatientDetail.tsx
+++ b/apps/web/src/pages/PatientDetail.tsx
@@ -1,6 +1,13 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams, Link } from 'react-router-dom';
-import { getPatient, type TaskSummary } from '../api/client';
+import {
+  getPatient,
+  streamAnalysis,
+  type TaskSummary,
+  type AnalysisFinding,
+  type AnalysisSummary,
+} from '../api/client';
 import { ageSexLabel } from '../lib/patient';
 import { PRIORITY_LABEL, dueLabel } from '../lib/task';
 
@@ -10,6 +17,56 @@ const PRIORITY_CLASS: Record<TaskSummary['priority'], string> = {
   medium: 'text-violet bg-violet-dim border-violet',
 };
 
+type FeedAccent = 'red' | 'violet' | 'emerald' | 'amber';
+type FeedState = 'idle' | 'streaming' | 'done';
+
+// Translates the mockup's `.feed{border-left:3px solid var(--ac)}` /
+// `.feed-label{color:var(--ac)}` CSS-custom-property pattern into per-accent
+// Tailwind class sets (no runtime CSS vars needed since the palette is fixed).
+const FEED_ACCENT: Record<FeedAccent, { border: string; label: string; cursor: string }> = {
+  red: { border: 'border-l-red', label: 'text-red', cursor: 'text-red' },
+  violet: { border: 'border-l-violet', label: 'text-violet', cursor: 'text-violet' },
+  emerald: { border: 'border-l-emerald', label: 'text-emerald', cursor: 'text-emerald' },
+  amber: { border: 'border-l-amber', label: 'text-amber', cursor: 'text-amber' },
+};
+
+function FeedBox({
+  label,
+  accent,
+  state,
+  children,
+}: {
+  label: string;
+  accent: FeedAccent;
+  state: FeedState;
+  children: React.ReactNode;
+}) {
+  const c = FEED_ACCENT[accent];
+  return (
+    <div
+      className={`bg-surface border border-border ${c.border} border-l-[3px] rounded-card flex flex-col overflow-hidden min-h-[112px]`}
+    >
+      <div className={`text-[9.5px] font-bold tracking-wide uppercase px-2.5 pt-2 pb-1 ${c.label}`}>{label}</div>
+      <div
+        className={`flex-1 px-2.5 pb-2.5 text-xs leading-relaxed overflow-y-auto ${
+          state === 'idle' ? 'text-text-muted' : 'text-text'
+        }`}
+      >
+        {children}
+        {state === 'streaming' && (
+          <span className={`feed-cursor ${c.cursor}`} aria-hidden="true">
+            ▌
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IdlePlaceholder() {
+  return <span className="italic text-text-dim">Awaiting analysis run…</span>;
+}
+
 export function PatientDetail() {
   const { id } = useParams<{ id: string }>();
   const { data, isLoading, isError, error } = useQuery({
@@ -17,6 +74,32 @@ export function PatientDetail() {
     queryFn: () => getPatient(id!),
     enabled: !!id,
   });
+
+  const [running, setRunning] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
+  const [riskText, setRiskText] = useState('');
+  const [findings, setFindings] = useState<AnalysisFinding[]>([]);
+  const [summary, setSummary] = useState<AnalysisSummary | null>(null);
+
+  const riskState: FeedState = !hasRun ? 'idle' : running ? 'streaming' : 'done';
+
+  async function handleRunAnalysis() {
+    if (!id || running) return;
+    setRunning(true);
+    setHasRun(true);
+    setRiskText('');
+    setFindings([]);
+    setSummary(null);
+    try {
+      await streamAnalysis(id, {
+        onToken: (text) => setRiskText((prev) => prev + text),
+        onFinding: (flag) => setFindings((prev) => [...prev, flag]),
+        onComplete: (result) => setSummary(result),
+      });
+    } finally {
+      setRunning(false);
+    }
+  }
 
   return (
     <div>
@@ -29,13 +112,69 @@ export function PatientDetail() {
 
       {data && (
         <div className="mt-4">
-          {/* Top bar matches reference-materials/caresync-ai.html's .pt-bar — the
-              "Run Analysis" button in that reference is S2 (no agent exists yet),
-              so it's intentionally left out here per the S1 honest-staging rule. */}
+          {/* Top bar matches reference-materials/caresync-ai.html's .pt-bar. */}
           <div className="h-11 flex items-center gap-2.5 px-4 -mx-6 -mt-6 mb-6 border-b border-border bg-surface">
             <span className="text-section font-bold text-text">{data.patient.name}</span>
             <span className="text-body text-text-muted">{ageSexLabel(data.patient.birthDate, data.patient.gender)}</span>
             <span className="font-mono text-xs text-text-dim flex-1 truncate">| Patient/{data.patient.id}</span>
+            <button
+              onClick={handleRunAnalysis}
+              disabled={running}
+              className="flex items-center gap-2 bg-cyan-dim border border-cyan text-cyan font-mono text-label font-bold tracking-wide px-4 py-1.5 rounded-md disabled:opacity-85 disabled:cursor-default"
+            >
+              {running ? (
+                <span className="w-3 h-3 rounded-full border-2 border-cyan/25 border-t-cyan animate-spin" aria-hidden="true" />
+              ) : (
+                <svg width="10" height="12" viewBox="0 0 10 12" fill="none" aria-hidden="true">
+                  <path d="M1 1.2v9.6L9 6 1 1.2Z" fill="#00C8FF" />
+                </svg>
+              )}
+              <span>{running ? 'Analyzing…' : 'Run Analysis'}</span>
+            </button>
+          </div>
+
+          {/* Feeds grid matches reference-materials/caresync-ai.html's .feeds — the
+              agent-graph canvas above it is out of scope (S4). Risk Agent is live
+              this slice; Care Gap/SDOH/Action Planner stay honest idle placeholders
+              until S3 wires their agents up. */}
+          <div className="grid grid-cols-4 gap-2.5 mb-6">
+            <FeedBox label="Risk Agent" accent="red" state={riskState}>
+              {!hasRun ? (
+                <IdlePlaceholder />
+              ) : (
+                <>
+                  <span>{riskText}</span>
+                  {findings.length > 0 && (
+                    <div className="mt-1.5 flex flex-wrap gap-1">
+                      {findings.map((flag, i) => (
+                        <span
+                          key={`${flag.fhirResourceId}-${i}`}
+                          className="font-mono text-[10px] text-text-dim bg-bg border border-border rounded-chip px-1.5 py-0.5"
+                        >
+                          {flag.fhirResourceId}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {summary && (
+                    <div className="mt-2 pt-2 border-t border-border text-[11px] text-text-muted">
+                      <span data-testid="risk-summary">
+                        {summary.riskLevel} risk · score {summary.riskScore}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </FeedBox>
+            <FeedBox label="Care Gap" accent="violet" state="idle">
+              <IdlePlaceholder />
+            </FeedBox>
+            <FeedBox label="SDOH" accent="emerald" state="idle">
+              <IdlePlaceholder />
+            </FeedBox>
+            <FeedBox label="Action Planner" accent="amber" state="idle">
+              <IdlePlaceholder />
+            </FeedBox>
           </div>
 
           <h2 className="text-section text-text mb-2">Active Conditions</h2>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     globals: true,
+    // Playwright specs live under e2e/ and run via `npm run test:e2e`;
+    // exclude them here so `vitest run` doesn't try to collect them too.
+    exclude: ['e2e/**', 'node_modules/**'],
   },
 })

--- a/docs/plans/caresync-ai/implementation-plan.md
+++ b/docs/plans/caresync-ai/implementation-plan.md
@@ -82,3 +82,70 @@
 
 ### Definition of done (S1)
 A–D green, `npm run test:api` passing, D2 smoke passes end-to-end. If B6 trails, the SMART honest-staging note is recorded in `plan.md` §3.
+
+---
+
+## Iteration 2 — S2 Single-agent analysis with citation enforcement — 2026-07-04
+
+**Spec:** `prd.md` · **Slice:** S2 (`issues.md`) · **Decisions:** `plan.md` GD11 (citation enforcement is real, core P3/P4), GD13 (agents on Claude Sonnet 5), GD2 (cache/replay — *deferred to S4*).
+
+**Goal:** On Maria's detail view, "Run Analysis" dispatches one live **Risk agent** (Claude Sonnet 5, structured output) over her retrieved FHIR bundle; findings stream to a single feed box over SSE, and every `fhirResourceId` the agent emits is validated against the IDs actually present in the bundle — fabricated citations are dropped before they reach the UI.
+
+**Architecture:** New `apps/api/src/agents/` module: a pure **citation validator** (Seam 2), a `getPatientBundle` read on the existing audited `FhirReadService` (backed by HAPI `$everything`), and a single `runRiskAgent` function. A new SSE route streams findings and runs each through the validator before emit. Frontend adds the "Run Analysis" control and one streaming Risk feed box to `PatientDetail` (W03), consuming SSE via `fetch` streaming. **This slice deliberately stays at one agent** — S3 adds the other three + Action Planner Tasks (and extracts the shared agent interface then), S4 adds the agent-graph canvas + cache. No DB schema change (S2 persists nothing beyond the existing audit spine).
+
+**Tech Stack (delta):** `@anthropic-ai/sdk` (Claude Sonnet 5, `claude-sonnet-5`, streaming + tool-based structured output) · HAPI `Patient/$everything` · SSE over Express `text/event-stream` · `fetch` ReadableStream on the client.
+
+**Ponytail pass applied:** one agent, as a plain function — no `Agent` interface until S3 has four real agents to generalize from; `$everything` instead of a per-type read fan-out, with `validIds` derived from the returned bundle (single source of truth); no client-factory module (the SDK client is the abstraction); no cache/persistence, no canvas (S4); no shared `packages/types` yet (agent output type lives in `apps/api`, imported by the client until S3 needs sharing); reuse the existing `buildApp`/defaulted-param test pattern, no new harness.
+
+### Phase A — Agent foundation & contracts (backend, test-first)
+
+- [ ] **A1. Anthropic SDK + config.** Add `@anthropic-ai/sdk`; `ANTHROPIC_API_KEY` in `apps/api/.env.example`; a module-level `anthropic = new Anthropic()` (reads the key from env) + `MODEL = 'claude-sonnet-5'` const in `riskAgent.ts`.
+  - *Domain rule:* agent model is Claude Sonnet 5 (GD13).
+  - *ponytail:* no `anthropic.ts` factory module — the SDK client *is* the abstraction; one `new Anthropic()` covers it. *skipped:* Haiku fallback (GD13 note — only if latency/cost pressure appears).
+
+- [ ] **A2. Citation validator — Seam 2 (pure module, TDD).** `src/agents/citationValidator.ts`: `validateCitations(flags, validIds) → { valid, dropped }`, no I/O. Given agent flags each carrying a `fhirResourceId` and the set of valid `ResourceType/id` strings, partition into passed vs dropped/flagged.
+  - *Domain rule:* backend validates every citation against the bundle and drops/flags hallucinated IDs (GD11) — the non-negotiable innovation.
+  - *Test (Vitest/Jest, first):* one in-bundle citation + one fabricated → valid passed, fabricated dropped; empty flags → empty result; case/whitespace normalization defined by the test.
+
+- [ ] **A3. Patient bundle retrieval (extend audited `FhirReadService`).** Add `getPatientBundle(actor, patientId)` → `{ resources, validIds }`, backed by a **single** `GET /Patient/{id}/$everything` (native HAPI operation — returns the whole record in one Bundle) through the existing audited `fhirFetch` + role `guard`. `validIds` is **derived from `resources`** (`new Set(resources.map(r => \`${r.resourceType}/${r.id}\`))`) — never assembled separately, so the agent's input and the citation-check set cannot drift.
+  - *Domain terms:* FHIR R4 `$everything`; "bundle" = the retrieved resource set citations are checked against (GD11).
+  - *ponytail:* `$everything` replaces a per-type fan-out (getPatient + getConditions + getObservations…) — one call, one audit row, and citation validity = "was in the record we read," which is exactly GD11.
+  - *Test (Supertest vs test HAPI):* Maria's bundle contains her known conditions + labs; `validIds` matches the returned resource ids 1:1; a Social-Worker-scoped read still denies (`guard` on `clinical`).
+
+### Phase B — Risk agent service + SSE (backend, test-first)
+
+- [ ] **B1. Risk agent (`runRiskAgent`).** `src/agents/riskAgent.ts`: a plain `runRiskAgent(bundle): AsyncIterable<AgentEvent>` on Claude Sonnet 5 with **structured output** (tool schema): `{ riskScore, riskLevel, flags: [{ text, fhirResourceId }], readmissionProbability }`.
+  - *Domain rule:* structured output; every flag cites a FHIR resource ID (GD11).
+  - *ponytail:* **no `Agent` interface yet** — one implementation. S3 extracts the shared interface from the four real agents (generalize from variation you can see, not from one guess).
+  - *Test:* prompt-build + response-parse against a **mocked Anthropic client** (no live call in CI); the live call is proven in D3, labeled *live* vs the *local-mock* unit evidence.
+
+- [ ] **B2. Analysis SSE route + validation gate.** `createAnalysisRouter(fhirService, runAgent = runRiskAgent)` — the agent fn is a defaulted param so tests pass a stub without a live call. `POST /api/patients/:id/analysis` responds `text/event-stream`: streams the agent's findings incrementally (`finding` events for the live feed) then a `complete` event. **Each flag's `fhirResourceId` passes through the A2 validator against the A3 bundle IDs before emit** — dropped citations never reach the client. `requireAuth` applies; wire into `index.ts`.
+  - *Domain rule:* no finding reaches the UI citing a resource absent from the retrieved bundle (GD11); the analysis read is audited.
+  - *Test (Supertest, boundary — S2 acceptance):* stub agent yields one in-bundle + one fabricated citation → the streamed result contains **only** the valid citation, and *all* returned citations resolve in the bundle; an audit row is written for the analysis read.
+  - *Decision (streaming mechanics):* stream the agent's text output token-wise into the feed for the live effect, and emit validated structured flags as discrete `finding` events; exact delta handling is TDD-driven. *skipped:* GET/`EventSource` variant — client uses `fetch` streaming so it can send the `Authorization` header (no token-in-query hack).
+
+### Phase C — Frontend: Run Analysis + streaming Risk feed
+
+- [ ] **C1. API client streaming.** `streamAnalysis(patientId, handlers)` in `src/api/client.ts` using `fetch` + `ReadableStream`, attaching the auth header and parsing SSE `finding`/`complete` events.
+
+- [ ] **C2. `PatientDetail` "Run Analysis" + Risk feed box (W03, mockup fidelity).** Add the **Run Analysis** control (`#runLabel` in `reference-materials/caresync-ai.html`) and one **Risk Agent feed box** (`.feed` red accent, `.feed-text.streaming` blinking cursor) that renders streamed text incrementally and validated flags as citation chips (`Condition/…`, `Observation/…` in mono, matching the existing `Task/{id}` treatment).
+  - *Mockup-fidelity deviations (recorded per CLAUDE.md UI rules):* the other three feed boxes (Care Gap/SDOH/Action Planner) render as honest **idle placeholders** ("Awaiting analysis run…", as in the mockup) — wired in **S3**; the agent-graph canvas is **omitted** — built in **S4**. Structural fidelity for the Risk feed itself targets ≥80%.
+  - *Test (Vitest, mocked stream):* text renders incrementally; a validated finding with its FHIR citation chip appears; the idle placeholders stay idle.
+
+### Phase D — Verification (Seam 2 + E2E)
+
+- [ ] **D1. Unit + API suites green.** `npm run test:api` (validator Seam 2 + analysis-route boundary + bundle read) and `npm run test:web` pass.
+
+- [ ] **D2. Frontend E2E (`frontend-e2e-verification`).** Playwright: log in as Coordinator → open Maria → **Run Analysis** → feed streams incrementally → a validated finding with its FHIR citation renders. Add alongside the S1 specs in `apps/web/e2e/`.
+
+- [ ] **D3. Live-call evidence.** One live run against real Claude Sonnet 5 confirming structured output + genuine streaming; record it in the slice's verification notes labeled *live* (vs *local-mock* for CI). Confirm a deliberately fabricated citation is dropped end-to-end.
+
+### Rollback / safety
+Additive only — no DB migration (no persistence until S4's cache). Disposable HAPI + local SQLite reset as in S1 (`docker compose down -v`). Unset `ANTHROPIC_API_KEY` to disable live analysis; the route degrades to an explicit error, not a fake result (honest staging).
+
+### Definition of done (S2) — maps to `issues.md` acceptance
+- Run Analysis triggers a live Claude call producing structured Risk output (B1, D3).
+- Findings stream over SSE and render incrementally in one feed box (B2, C2, D2).
+- Citation validator passes an in-bundle citation and drops a fabricated one (A2 Seam 2).
+- No finding citing an out-of-bundle ID reaches the UI (B2 gate; D2/D3 end-to-end).
+- Citation-validator unit tests + API-boundary test asserting all returned citations resolve in the bundle (A2, B2; `npm run test:api` green).

--- a/docs/plans/caresync-ai/implementation-plan.md
+++ b/docs/plans/caresync-ai/implementation-plan.md
@@ -87,65 +87,582 @@ A–D green, `npm run test:api` passing, D2 smoke passes end-to-end. If B6 trail
 
 ## Iteration 2 — S2 Single-agent analysis with citation enforcement — 2026-07-04
 
-**Spec:** `prd.md` · **Slice:** S2 (`issues.md`) · **Decisions:** `plan.md` GD11 (citation enforcement is real, core P3/P4), GD13 (agents on Claude Sonnet 5), GD2 (cache/replay — *deferred to S4*).
+**Spec:** `prd.md` · **Slice:** S2 (`issues.md`) · **Decisions:** `plan.md` GD11 (citation enforcement is real, core P3/P4), GD13 (agent provider **revised 2026-07-04**: OpenAI `gpt-5.5`, not Claude Sonnet 5 — no Anthropic key was available for the D3 live-call verification; user-approved straight substitution under the same `runRiskAgent`/`AgentEvent` contract), GD2 (cache/replay — *deferred to S4*).
 
-**Goal:** On Maria's detail view, "Run Analysis" dispatches one live **Risk agent** (Claude Sonnet 5, structured output) over her retrieved FHIR bundle; findings stream to a single feed box over SSE, and every `fhirResourceId` the agent emits is validated against the IDs actually present in the bundle — fabricated citations are dropped before they reach the UI.
+**Goal:** On Maria's detail view, "Run Analysis" dispatches one live **Risk agent** (OpenAI `gpt-5.5`, structured output via the Responses API) over her retrieved FHIR bundle; findings stream to a single feed box over SSE, and every `fhirResourceId` the agent emits is validated against the IDs actually present in the bundle — fabricated citations are dropped before they reach the UI.
 
 **Architecture:** New `apps/api/src/agents/` module: a pure **citation validator** (Seam 2), a `getPatientBundle` read on the existing audited `FhirReadService` (backed by HAPI `$everything`), and a single `runRiskAgent` function. A new SSE route streams findings and runs each through the validator before emit. Frontend adds the "Run Analysis" control and one streaming Risk feed box to `PatientDetail` (W03), consuming SSE via `fetch` streaming. **This slice deliberately stays at one agent** — S3 adds the other three + Action Planner Tasks (and extracts the shared agent interface then), S4 adds the agent-graph canvas + cache. No DB schema change (S2 persists nothing beyond the existing audit spine).
 
-**Tech Stack (delta):** `@anthropic-ai/sdk` (Claude Sonnet 5, `claude-sonnet-5`, streaming + tool-based structured output) · HAPI `Patient/$everything` · SSE over Express `text/event-stream` · `fetch` ReadableStream on the client.
+**Tech Stack (delta):** `openai` (Node SDK, `gpt-5.5`, Responses API — `client.responses.create({stream:true})`, flat `tools:[{type:'function',...}]`, streamed `response.output_text.delta`/`response.function_call_arguments.*` events) · HAPI `Patient/$everything` · SSE over Express `text/event-stream` · `fetch` ReadableStream on the client.
 
 **Ponytail pass applied:** one agent, as a plain function — no `Agent` interface until S3 has four real agents to generalize from; `$everything` instead of a per-type read fan-out, with `validIds` derived from the returned bundle (single source of truth); no client-factory module (the SDK client is the abstraction); no cache/persistence, no canvas (S4); no shared `packages/types` yet (agent output type lives in `apps/api`, imported by the client until S3 needs sharing); reuse the existing `buildApp`/defaulted-param test pattern, no new harness.
 
 ### Phase A — Agent foundation & contracts (backend, test-first)
 
-- [ ] **A1. Anthropic SDK + config.** Add `@anthropic-ai/sdk`; `ANTHROPIC_API_KEY` in `apps/api/.env.example`; a module-level `anthropic = new Anthropic()` (reads the key from env) + `MODEL = 'claude-sonnet-5'` const in `riskAgent.ts`.
-  - *Domain rule:* agent model is Claude Sonnet 5 (GD13).
-  - *ponytail:* no `anthropic.ts` factory module — the SDK client *is* the abstraction; one `new Anthropic()` covers it. *skipped:* Haiku fallback (GD13 note — only if latency/cost pressure appears).
+- [x] **A1 (revised). OpenAI SDK + config.** Add `openai`; `OPENAI_API_KEY` in `apps/api/.env.example`; `MODEL = 'gpt-5.5'` const in `riskAgent.ts`. *(Checkbox corrected 2026-07-04 — this was already implemented and checked in `tasks/todo.md`; the client construction was made lazy in the post-review pass below, not module-level, to fix a boot-time crash.)*
+  - *Domain rule:* agent model is OpenAI `gpt-5.5` (GD13, revised 2026-07-04 — see plan.md).
+  - *ponytail:* no factory module — the SDK client *is* the abstraction; one `new OpenAI()` covers it.
 
-- [ ] **A2. Citation validator — Seam 2 (pure module, TDD).** `src/agents/citationValidator.ts`: `validateCitations(flags, validIds) → { valid, dropped }`, no I/O. Given agent flags each carrying a `fhirResourceId` and the set of valid `ResourceType/id` strings, partition into passed vs dropped/flagged.
+- [x] **A2. Citation validator — Seam 2 (pure module, TDD).** `src/agents/citationValidator.ts`: `validateCitations(flags, validIds) → { valid, dropped }`, no I/O. Given agent flags each carrying a `fhirResourceId` and the set of valid `ResourceType/id` strings, partition into passed vs dropped/flagged.
   - *Domain rule:* backend validates every citation against the bundle and drops/flags hallucinated IDs (GD11) — the non-negotiable innovation.
   - *Test (Vitest/Jest, first):* one in-bundle citation + one fabricated → valid passed, fabricated dropped; empty flags → empty result; case/whitespace normalization defined by the test.
 
-- [ ] **A3. Patient bundle retrieval (extend audited `FhirReadService`).** Add `getPatientBundle(actor, patientId)` → `{ resources, validIds }`, backed by a **single** `GET /Patient/{id}/$everything` (native HAPI operation — returns the whole record in one Bundle) through the existing audited `fhirFetch` + role `guard`. `validIds` is **derived from `resources`** (`new Set(resources.map(r => \`${r.resourceType}/${r.id}\`))`) — never assembled separately, so the agent's input and the citation-check set cannot drift.
+- [x] **A3. Patient bundle retrieval (extend audited `FhirReadService`).** Add `getPatientBundle(actor, patientId)` → `{ resources, validIds }`, backed by a **single** `GET /Patient/{id}/$everything` (native HAPI operation — returns the whole record in one Bundle) through the existing audited `fhirFetch` + role `guard`. `validIds` is **derived from `resources`** (`new Set(resources.map(r => \`${r.resourceType}/${r.id}\`))`) — never assembled separately, so the agent's input and the citation-check set cannot drift.
   - *Domain terms:* FHIR R4 `$everything`; "bundle" = the retrieved resource set citations are checked against (GD11).
   - *ponytail:* `$everything` replaces a per-type fan-out (getPatient + getConditions + getObservations…) — one call, one audit row, and citation validity = "was in the record we read," which is exactly GD11.
   - *Test (Supertest vs test HAPI):* Maria's bundle contains her known conditions + labs; `validIds` matches the returned resource ids 1:1; a Social-Worker-scoped read still denies (`guard` on `clinical`).
 
 ### Phase B — Risk agent service + SSE (backend, test-first)
 
-- [ ] **B1. Risk agent (`runRiskAgent`).** `src/agents/riskAgent.ts`: a plain `runRiskAgent(bundle): AsyncIterable<AgentEvent>` on Claude Sonnet 5 with **structured output** (tool schema): `{ riskScore, riskLevel, flags: [{ text, fhirResourceId }], readmissionProbability }`.
+- [x] **B1 (revised). Risk agent (`runRiskAgent`).** `src/agents/riskAgent.ts`: a plain `runRiskAgent(bundle): AsyncIterable<AgentEvent>` on **OpenAI `gpt-5.5`** (Responses API) with **structured output** (`text.format` json_schema and/or a `report_risk` function tool): `{ riskScore, riskLevel, flags: [{ text, fhirResourceId }], readmissionProbability }`. Same `AgentEvent`/`RiskOutput` contract as the original Anthropic version — B2/C1/C2 need zero changes.
   - *Domain rule:* structured output; every flag cites a FHIR resource ID (GD11).
   - *ponytail:* **no `Agent` interface yet** — one implementation. S3 extracts the shared interface from the four real agents (generalize from variation you can see, not from one guess).
-  - *Test:* prompt-build + response-parse against a **mocked Anthropic client** (no live call in CI); the live call is proven in D3, labeled *live* vs the *local-mock* unit evidence.
+  - *Test:* prompt-build + response-parse against a **mocked OpenAI client** (no live call in CI); the live call is proven in D3, labeled *live* vs the *local-mock* unit evidence.
 
-- [ ] **B2. Analysis SSE route + validation gate.** `createAnalysisRouter(fhirService, runAgent = runRiskAgent)` — the agent fn is a defaulted param so tests pass a stub without a live call. `POST /api/patients/:id/analysis` responds `text/event-stream`: streams the agent's findings incrementally (`finding` events for the live feed) then a `complete` event. **Each flag's `fhirResourceId` passes through the A2 validator against the A3 bundle IDs before emit** — dropped citations never reach the client. `requireAuth` applies; wire into `index.ts`.
+- [x] **B2. Analysis SSE route + validation gate.** `createAnalysisRouter(fhirService, runAgent = runRiskAgent)` — the agent fn is a defaulted param so tests pass a stub without a live call. `POST /api/patients/:id/analysis` responds `text/event-stream`: streams the agent's findings incrementally (`finding` events for the live feed) then a `complete` event. **Each flag's `fhirResourceId` passes through the A2 validator against the A3 bundle IDs before emit** — dropped citations never reach the client. `requireAuth` applies; wire into `index.ts`.
   - *Domain rule:* no finding reaches the UI citing a resource absent from the retrieved bundle (GD11); the analysis read is audited.
   - *Test (Supertest, boundary — S2 acceptance):* stub agent yields one in-bundle + one fabricated citation → the streamed result contains **only** the valid citation, and *all* returned citations resolve in the bundle; an audit row is written for the analysis read.
   - *Decision (streaming mechanics):* stream the agent's text output token-wise into the feed for the live effect, and emit validated structured flags as discrete `finding` events; exact delta handling is TDD-driven. *skipped:* GET/`EventSource` variant — client uses `fetch` streaming so it can send the `Authorization` header (no token-in-query hack).
 
 ### Phase C — Frontend: Run Analysis + streaming Risk feed
 
-- [ ] **C1. API client streaming.** `streamAnalysis(patientId, handlers)` in `src/api/client.ts` using `fetch` + `ReadableStream`, attaching the auth header and parsing SSE `finding`/`complete` events.
+- [x] **C1. API client streaming.** `streamAnalysis(patientId, handlers)` in `src/api/client.ts` using `fetch` + `ReadableStream`, attaching the auth header and parsing SSE `finding`/`complete` events.
 
-- [ ] **C2. `PatientDetail` "Run Analysis" + Risk feed box (W03, mockup fidelity).** Add the **Run Analysis** control (`#runLabel` in `reference-materials/caresync-ai.html`) and one **Risk Agent feed box** (`.feed` red accent, `.feed-text.streaming` blinking cursor) that renders streamed text incrementally and validated flags as citation chips (`Condition/…`, `Observation/…` in mono, matching the existing `Task/{id}` treatment).
+- [x] **C2. `PatientDetail` "Run Analysis" + Risk feed box (W03, mockup fidelity).** Add the **Run Analysis** control (`#runLabel` in `reference-materials/caresync-ai.html`) and one **Risk Agent feed box** (`.feed` red accent, `.feed-text.streaming` blinking cursor) that renders streamed text incrementally and validated flags as citation chips (`Condition/…`, `Observation/…` in mono, matching the existing `Task/{id}` treatment).
   - *Mockup-fidelity deviations (recorded per CLAUDE.md UI rules):* the other three feed boxes (Care Gap/SDOH/Action Planner) render as honest **idle placeholders** ("Awaiting analysis run…", as in the mockup) — wired in **S3**; the agent-graph canvas is **omitted** — built in **S4**. Structural fidelity for the Risk feed itself targets ≥80%.
   - *Test (Vitest, mocked stream):* text renders incrementally; a validated finding with its FHIR citation chip appears; the idle placeholders stay idle.
 
 ### Phase D — Verification (Seam 2 + E2E)
 
-- [ ] **D1. Unit + API suites green.** `npm run test:api` (validator Seam 2 + analysis-route boundary + bundle read) and `npm run test:web` pass.
+- [x] **D1. Unit + API suites green.** `npm run test:api` (49/49) and `npm run test:web` (14/14) pass.
 
-- [ ] **D2. Frontend E2E (`frontend-e2e-verification`).** Playwright: log in as Coordinator → open Maria → **Run Analysis** → feed streams incrementally → a validated finding with its FHIR citation renders. Add alongside the S1 specs in `apps/web/e2e/`.
+- [x] **D2. Frontend E2E (`frontend-e2e-verification`).** Playwright: log in as Coordinator → open Maria → **Run Analysis** → feed streams incrementally → a validated finding with its FHIR citation renders. Added `apps/web/e2e/patient-analysis.spec.ts` alongside the S1 specs. **Evidence strength: packaged UI / local-mock** for the streaming/finding path (route-intercepted SSE, real event framing, real citation id) — login/nav/idle-state/button-state assertions run against the real local stack. Does not exercise the server-side citation-drop path (covered by B2's Supertest) or a live model call (that's D3).
 
-- [ ] **D3. Live-call evidence.** One live run against real Claude Sonnet 5 confirming structured output + genuine streaming; record it in the slice's verification notes labeled *live* (vs *local-mock* for CI). Confirm a deliberately fabricated citation is dropped end-to-end.
+- [x] **D3 (revised). Live-call evidence — done 2026-07-04.** One real `POST /api/patients/maria-chen/analysis` call against **OpenAI `gpt-5.5`** (`OPENAI_API_KEY` in root `.env`, loaded via `apps/api/src/env.ts`), API booted standalone (port 4001) against the live HAPI container. **Evidence strength: live.**
+  - Streamed ~70 `token` events narrating real clinical reasoning (CHF readmission risk, BNP/HbA1c/eGFR/K+, SDOH, depression, pending med-rec) — genuine token-by-token streaming, not canned text.
+  - 9 `finding` events, each independently cross-checked against a fresh `Patient/maria-chen/$everything` fetch: **all 9 `fhirResourceId`s resolve in the real bundle** (`Encounter/maria-chen-chf-admit`, `Condition/maria-chen-chf`, `Observation/maria-chen-{bnp,hba1c,egfr,potassium,sdoh}`, `Condition/maria-chen-depression`, `Task/maria-chen-task-medrec`).
+  - `complete` event: `{riskScore:88, riskLevel:"critical", readmissionProbability:0.62, findingCount:9, droppedCount:0}` — the model didn't fabricate anything on this run, so the drop path wasn't exercised live.
+  - **Fabrication-drop proof:** ran the *actual production* `validateCitations` (not a reimplementation) against these 9 real live flags plus one synthetic fabricated flag (`Observation/does-not-exist-99999`) → `valid: 9, dropped: 1`, fabricated id confirmed absent from `valid`. Combines real live model output with a deterministic proof of the drop mechanism GD11 requires, since a live model can't be forced to hallucinate on demand.
 
 ### Rollback / safety
-Additive only — no DB migration (no persistence until S4's cache). Disposable HAPI + local SQLite reset as in S1 (`docker compose down -v`). Unset `ANTHROPIC_API_KEY` to disable live analysis; the route degrades to an explicit error, not a fake result (honest staging).
+Additive only — no DB migration (no persistence until S4's cache). Disposable HAPI + local SQLite reset as in S1 (`docker compose down -v`). Unset `OPENAI_API_KEY` to disable live analysis; the route degrades to an explicit error, not a fake result (honest staging) — **true as of the post-review fixes below; it was not true before them (E3).**
+
+### Post-review fixes — done 2026-07-04
+
+`verification-before-completion` and `code-review` (see `verification.md`, `review.md`) found three real defects and two duplicated-type Standards findings, none exercised by the D1–D3 evidence above (which only covers the success path). All fixed, test-first, same pass:
+
+- [x] **E1. SSE error handling.** `routes/analysis.ts`'s `for await` agent-streaming loop had no error handling; an agent failure mid-stream (proven to happen — `riskAgent.test.ts`'s "throws if the model never calls report_risk" case — or any transient OpenAI failure) hung the client forever and, since `res.writeHead(200)` had already run, produced an unhandled promise rejection with no process-level handler — crashing the whole API under Node 22's default `--unhandled-rejections=throw`. Fixed: the loop is wrapped in try/catch; on failure it emits an `error` SSE event and ends the response. *Test:* `analysis.test.ts` — a throwing stub agent yields an `error` event and no `complete` event, response doesn't hang.
+- [x] **E2. Narration citations bypassed GD11.** Only the structured `flags` array was validated against the bundle; the agent's free-text narration (streamed as `token` events) could mention a `ResourceType/id` with zero validation. Fixed: `citationValidator.ts` gained `redactUnvalidatedCitations` (pure, regex-based) and `createNarrationBuffer` (holds back a 96-char tail so an id split across two token deltas is still whole when checked, then redacts before releasing — trades a small bounded delay in the streaming effect for a real enforcement guarantee, instead of buffering the whole narration and losing the streaming effect entirely). Wired into `routes/analysis.ts`'s token-emit path. *Tests:* 8 new cases in `citationValidator.test.ts` (redaction, buffering, split-across-deltas) + a route-level case in `analysis.test.ts` proving a fabricated id in narration is redacted end to end while a valid one passes through.
+- [x] **E3. Boot-time crash on missing API key.** `riskAgent.ts`'s `export const openai = new OpenAI()` ran at module import time and throws synchronously with no key — since `index.ts` imports the analysis route unconditionally at startup, an unset key crashed the *whole process at boot*, contradicting this section's own rollback claim above. Fixed: the client is now built lazily on first use (`getOpenAiClient()`), so a missing key only fails the one request that needs it. `apps/api/jest.setup.ts` (a placeholder-key workaround for the old eager-throw) is now unnecessary and was deleted, along with its `jest.config.js` wiring. *Tests:* `riskAgent.test.ts` — importing the module without a key doesn't throw; calling the agent without a key throws only then.
+- [x] **E4 (Standards). Duplicated `PatientBundle`/`AgentFlag` types.** Both were independently redeclared in 2–3 files instead of imported from one source (Shotgun Surgery risk on the next shape change). Fixed: `PatientBundle` is now exported once from `fhir/client.ts` (where `getPatientBundle` produces it) and imported by `riskAgent.ts`/`routes/analysis.ts`; `AgentFlag` is exported once from `citationValidator.ts` (the Seam 2 module) and imported by `riskAgent.ts`. No behavior change — confirmed by `tsc` build + full suite green after.
+
+Fresh evidence after all four fixes: `npm run test:api` — **15 suites / 61 tests** (up from 49; +12 new tests across the three fix areas), `npm run build`/`lint` clean (apps/api and apps/web unaffected).
 
 ### Definition of done (S2) — maps to `issues.md` acceptance
-- Run Analysis triggers a live Claude call producing structured Risk output (B1, D3).
+- Run Analysis triggers a live OpenAI call producing structured Risk output (B1, D3).
 - Findings stream over SSE and render incrementally in one feed box (B2, C2, D2).
 - Citation validator passes an in-bundle citation and drops a fabricated one (A2 Seam 2).
 - No finding citing an out-of-bundle ID reaches the UI (B2 gate; D2/D3 end-to-end).
 - Citation-validator unit tests + API-boundary test asserting all returned citations resolve in the bundle (A2, B2; `npm run test:api` green).
+
+---
+
+## Iteration 3 — S3 Four-agent orchestration + FHIR Task creation — 2026-07-04
+
+**Spec:** `prd.md` · **Slice:** S3 (`issues.md`) · **Decisions:** `plan.md` GD11 (citations real, all four agents), GD13 (agent provider **revised 2026-07-04**: OpenAI `gpt-5.5` via the `openai` SDK Responses API — not Claude Sonnet 5; the migrated S2 `runRiskAgent` is the reference), and the four agent I/O contracts in `prd.md` §Implementation Decisions.
+
+**Goal:** Extend the single Risk agent to the full care team. An **Orchestrator** dispatches **Risk, Care Gap, SDOH, and Action Planner** in parallel over Maria's `$everything` bundle; each streams to its own per-agent feed box; the Action Planner synthesizes the other three into prioritized **FHIR Task** resources written to HAPI, each citing the exact resources behind it. Citation enforcement (Seam 2) applies to all four.
+
+**Architecture:** This is the slice where the shared **`Agent` interface is extracted from the four real agents** (generalize from visible variation, not from one guess — deferred from S2 on purpose). `src/agents/` grows `careGapAgent.ts`, `sdohAgent.ts`, `actionPlannerAgent.ts`, and an `orchestrator.ts` that runs the first three in parallel, awaits their structured results, then feeds those into the Action Planner. The analysis route (`createAnalysisRouter`) switches from `runAgent = runRiskAgent` to `runAnalysis = orchestrate` (same defaulted-param, stubbable pattern) and tags every SSE event with an `agentId` so the client can route it to the right feed box. Task writes go on the **one existing FHIR client** — add `createTask`/`replacePatientTasks` to the current `FhirReadService` class (they route through the same audited, token-bearing `fetch`), auditing each write. **Do not** spin up a sibling `FhirWriteService`: one write-method group doesn't earn a second class — just extend the client (rename to `FhirService` if the read-only name bothers you; a one-line rename, not a split). Re-running deletes the prior CareSync-authored Tasks + findings before creating new ones (clean replace).
+
+**Tech Stack (delta):** three more `openai` Responses-API function-tool agents (same shape as the migrated `runRiskAgent`, model `gpt-5.5`) · HAPI `POST /Task`, `DELETE`/conditional-delete for re-run replace · SSE events gain `agentId` · no new client transport (reuse `streamAnalysis`).
+
+**Ponytail pass applied:** extract the `Agent` interface **now** (four concrete agents exist — the S2 note said S3 is when to generalize), not a plugin registry; Action Planner consumes the other three agents' **already-parsed structured outputs**, not a re-read of the bundle; re-run replace via a tag/identifier query + delete, not a new "analysis session" table; one orchestrator function returning a merged `AsyncIterable`, no message bus; Tasks written straight to HAPI (the FHIR server *is* the store), no local Task mirror table.
+
+### Phase A — Agent interface + three new agents (backend, test-first)
+
+- [ ] **A1. Extract the `Agent` contract.** Define `Agent<TOutput>` (or a discriminated `AgentEvent` per agent) generalizing `runRiskAgent`'s shape: `(bundle) => AsyncIterable<AgentEvent>` where the terminal `result` carries the agent's structured output and each flag/gap/barrier/task carries a `fhirResourceId`/`fhirResources`. Refactor `riskAgent.ts` to implement it — **no behavior change**, existing S2 tests stay green.
+  - *ponytail:* interface extracted from four real implementations, not invented; keep it the minimum the orchestrator + validator need.
+
+- [ ] **A2. Care Gap agent (`runCareGapAgent`).** Structured output per `prd.md`: `{ gaps: [{gapType, description, lastDone, dueDate, urgency, fhirResourceId}] }`; reads CarePlan/Condition/Encounter/Observation from the bundle.
+  - *Domain rule:* Care Gap reads CarePlan/Encounter (S3 acceptance); every gap cites a FHIR resource id (GD11).
+  - *Test:* prompt-build + tool-result parse against a **mocked OpenAI client**; live call proven in D3.
+
+- [ ] **A3. SDOH agent (`runSdohAgent`).** Structured output `{ barriers: [{domain, finding, severity, fhirResourceId}], referralsNeeded: string[] }`; reads the **AHC-HRSN QuestionnaireResponse** + demographics from the bundle.
+  - *Domain rule:* SDOH agent reads the AHC-HRSN QuestionnaireResponse (S3 acceptance); barriers cite resource ids (GD11).
+  - *Test:* mocked-client parse; asserts a QuestionnaireResponse-derived barrier cites the QR id.
+
+- [ ] **A4. Action Planner agent (`runActionPlannerAgent`).** Input is the **three prior agents' structured outputs** (not the raw bundle); output `{ tasks: [{title, description, priority, assignTo, dueInDays, fhirResources}] }` where `fhirResources` are the ids that generated the task.
+  - *Domain rule:* Action Planner synthesizes the other three (GD/prd contract); each task cites its source resources (GD11).
+  - *ponytail:* consumes parsed outputs — no second bundle read, no re-derivation.
+  - *Test:* given three canned agent outputs, produces tasks whose `fhirResources` are a subset of the union of cited ids.
+
+### Phase B — Orchestrator + FHIR Task write (backend, test-first)
+
+- [ ] **B1. Orchestrator (`orchestrate(bundle)`).** Dispatch Risk + Care Gap + SDOH **in parallel** (`Promise`/merged async iteration), tag every streamed event with its `agentId`, collect the three structured results, then run Action Planner over them and stream its output too. Returns one `AsyncIterable<AgentEvent & {agentId}>`.
+  - *ponytail:* one function, merged iterable — no queue/worker infra (GD1 "self-contained service" is satisfied by module boundaries, not processes).
+  - *Test:* with four stub agents, all three parallel agents' events appear before the planner's, and the planner receives the three outputs.
+
+- [ ] **B2. FHIR Task write + re-run replace (audited).** Add `createTask(actor, task)` and `replacePatientTasks(actor, patientId, tasks)` to the FHIR client, going through the **same audited, token-bearing `fetch`** as reads (one audit row per write). `replace` first removes prior CareSync-authored Tasks for the patient (query by an author/tag identifier, then delete) so re-running is clean.
+  - *Domain rule:* Action Planner output becomes FHIR Task resources persisted in HAPI; re-run replaces prior Tasks cleanly (S3 acceptance); every write audited (S1 audit spine).
+  - *Test (Supertest vs test HAPI):* planner tasks are POSTed as FHIR Tasks resolvable in HAPI with their citations; a second run leaves exactly the new Task set (no duplicates); each write writes an audit row.
+
+- [ ] **B3. Analysis route → orchestration + validation gate for all four.** Swap `createAnalysisRouter`'s defaulted param from `runRiskAgent` to `runAnalysis = orchestrate`. Each agent's citations pass through the A2/S2 `validateCitations` gate against the bundle `validIds` **before emit and before Task creation** — a task whose citations all drop is not created. Emit `finding` events carrying `agentId`; emit a per-agent `complete`; emit `task` events for created Tasks.
+  - *Domain rule:* no finding/Task reaches the UI citing an out-of-bundle resource (GD11); the analysis read + Task writes are audited.
+  - *Test (Supertest, boundary — S3 acceptance):* one run yields findings from all four agents, creates the expected Tasks, and **every** returned citation (findings + Tasks) resolves in the bundle; a fabricated id injected via a stub is dropped everywhere.
+
+### Phase C — Frontend: four live feeds + Task cards from analysis
+
+- [ ] **C1. Client: route SSE by `agentId`.** Extend `streamAnalysis` handlers so `onFinding`/`onToken`/`onComplete` carry `agentId`, and add `onTask`. No new transport.
+
+- [ ] **C2. `PatientDetail`: light up all four feeds + render created Tasks (W03, mockup fidelity).** The three S2 idle placeholders (Care Gap violet / SDOH emerald / Action Planner amber) become **live streaming feeds** using the existing `FeedBox` component and per-agent accent already defined; created Tasks render as Task cards with their citation chips in the existing Tasks section.
+  - *Mockup-fidelity note (per CLAUDE.md UI rules):* completes the four-feed grid from `reference-materials/caresync-ai.html`; the **agent-graph canvas above the feeds is still omitted — built in S4**. Record this as the one remaining deviation for W03.
+  - *Test (Vitest, mocked stream):* a finding on each of the four `agentId`s renders in its own feed with the right accent; a `task` event renders a Task card with its citation chip.
+
+### Phase D — Verification (Seam 1/2 + E2E)
+
+- [ ] **D1. Unit + API suites green.** `npm run test:api` (four-agent boundary + Task write/replace + validator) and `npm run test:web`.
+- [ ] **D2. Frontend E2E (`frontend-e2e-verification`).** Playwright: Coordinator → Maria → Run Analysis → all four feeds stream → Task cards appear with citations. Extend the S2 spec.
+- [ ] **D3. Live-call evidence.** One live orchestrated run against OpenAI `gpt-5.5`; confirm all four produce structured output, Tasks land in HAPI, and a deliberately fabricated citation is dropped end-to-end. Label *live* vs *local-mock*.
+
+### Rollback / safety
+Task writes are additive to HAPI and reversible via `docker compose down -v`. Re-run replace only touches CareSync-authored Tasks (tag-scoped delete) — never Synthea/seed Tasks. No DB migration (analysis still persists nothing until S4 cache).
+
+### Definition of done (S3) — maps to `issues.md` acceptance
+- Four agents run in parallel from the Orchestrator; each streams to its own feed (B1, C2).
+- Action Planner output becomes FHIR Tasks persisted in HAPI (B2).
+- Each Task cites validated (non-fabricated) FHIR resources (B3, Seam 2).
+- SDOH reads AHC-HRSN QuestionnaireResponse; Care Gap reads CarePlan/Encounter (A2, A3).
+- Re-running replaces prior findings + Tasks cleanly (B2).
+- API-boundary test: all four agents' findings + created Tasks with resolvable citations (D1); E2E green (D2); live evidence (D3).
+
+---
+
+## Iteration 4 — S4 Agent-graph canvas + analysis cache/replay — 2026-07-04
+
+**Spec:** `prd.md` · **Slice:** S4 (`issues.md`) · **Decisions:** `plan.md` GD2 (cache + live re-run + recorded fallback — demo reliability is first-class), GD10 (native Canvas, no chart library).
+
+**Goal:** The signature W03 visual and the demo-reliability mechanism. A native **Canvas agent graph** (`requestAnimationFrame`, 5-node radial layout, bezier edges, particle flow, per-agent color, state machine `IDLE→INIT→DISPATCH→ANALYZING→SYNTHESIZING→COMPLETE`) visualizes the S3 orchestration; the last successful analysis per patient is **cached** and replays instantly/deterministically, while an explicit **live** trigger forces a fresh model run (OpenAI `gpt-5.5`) and re-caches.
+
+**Architecture:** Backend gains a small **analysis cache** — a SQLite `analysis_cache` table keyed by patient id holding the full validated result set (findings per agent + created Task ids + summary) as JSON, plus model version + timestamp. The analysis route reads: default request serves the cached result (replayed through the same SSE shape so the UI treatment is identical); `?live=1` runs the orchestrator, re-caches, and streams live. Frontend adds a `AgentGraph` canvas component driven by the analysis state machine, wired to the same stream events (node state transitions on `dispatch`/`finding`/`complete`). **No chart/animation library** — raw Canvas 2D + `requestAnimationFrame`, cleaned up on unmount.
+
+**Tech Stack (delta):** SQLite `analysis_cache` (better-sqlite3, JSON column) · `?live=1` query flag on the existing route · one Canvas 2D component (`requestAnimationFrame`, bezier, particles) — no dependency.
+
+**Ponytail pass applied:** cache is one table of JSON keyed by patient — not an event-sourced history; replay reuses the **exact SSE event shape** so there's one client code path (cache vs live differ only in a flag + latency); the canvas is one self-contained component reading a state enum, no animation framework, no WebGL; `?live=1` is a query flag, not a second endpoint.
+
+### Phase A — Analysis cache (backend, test-first)
+
+- [ ] **A1. `analysis_cache` schema + migrate.** Table `(patient_id PK, result_json, model_version, created_ts)`; idempotent migrate at boot (matches the S1 migrate pattern). Persist the **validated** result (post-citation-gate) so replay can never surface a dropped citation.
+  - *ponytail:* one row per patient (last successful run), overwritten on re-run — no history table (YAGNI until a "compare runs" feature exists).
+  - *Test:* write-then-read round-trips the full result; overwrite replaces.
+
+- [ ] **A2. Cache-aware analysis route.** On `POST /:id/analysis`: if `?live=1` → run orchestrator, persist to cache, stream live; else → if a cache row exists, **replay it** as the same `finding`/`task`/`complete` SSE events (optionally paced for the streaming feel); if no cache, fall back to a live run + cache.
+  - *Domain rule:* cached analysis replays deterministically without a live model call; explicit live trigger forces a fresh run and re-caches (S4 acceptance); cache is real prior output, not a script (GD2).
+  - *Test (Supertest):* seed a cache row → default request replays it with **zero** agent invocations (stub agent asserts not-called); `?live=1` invokes the (stub) orchestrator and updates the row.
+
+### Phase B — Agent-graph canvas (frontend)
+
+- [ ] **B1. Analysis state machine (client).** A small reducer/hook mapping stream events → graph state (`IDLE→INIT→DISPATCH→ANALYZING→SYNTHESIZING→COMPLETE`) and per-node status (Orchestrator + 4 agents). Pure and unit-testable.
+  - *Test (Vitest):* the documented event sequence drives the states in order; per-agent nodes flip to ANALYZING/COMPLETE on their events.
+
+- [ ] **B2. `AgentGraph` Canvas component (W03, mockup fidelity).** Native Canvas: 5-node radial layout (Orchestrator center + 4 agents), bezier edges, particle flow along active edges, per-agent color identity **consistent with the feed boxes and Task citation chips**, animated via `requestAnimationFrame` and torn down on unmount. Placed above the feeds grid per `reference-materials/caresync-ai.html`, closing W03's last deviation.
+  - *Domain rule:* no chart library (GD10); per-agent color consistent graph→feed→task (S4 acceptance).
+  - *ponytail:* one component, no lib; guard against SSR/`useEffect` leaks; respects `prefers-reduced-motion` by rendering the final state statically.
+  - *Verify:* graph animates through the state machine in sync with the streaming analysis (visual, in E2E/manual).
+
+- [ ] **B3. Live vs cached UI parity + trigger.** Wire a "Run live" affordance that hits `?live=1`; default Run Analysis serves cache. Both drive the identical graph + feeds treatment.
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (cache replay/live) + `npm run test:web` (state machine) green.
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Cached replay renders graph→feeds→tasks with no live call; the live trigger forces a fresh run; both produce the same UI treatment (GD2).
+
+### Rollback / safety
+Cache is a single SQLite table — deletable without affecting HAPI; `docker compose down -v` + delete SQLite resets. A stale/absent cache degrades to a live run, never a fake. Canvas is presentational — no data risk.
+
+### Definition of done (S4) — maps to `issues.md`
+- Canvas graph animates through the state machine in sync with streaming; no chart library (B2).
+- Per-agent color consistent node→feed→task (B2).
+- Cached analysis replays deterministically with no live model call; live trigger forces a fresh run + re-cache (A2, B3).
+- Cached and live runs share UI treatment; cache is real prior output (A1/A2, C2).
+
+---
+
+## Iteration 5 — S5 Population Dashboard + drill-in (Director) — 2026-07-04
+
+**Spec:** `prd.md` (stories 1–4) · **Slice:** S5 (`issues.md`) · **Decisions:** GD3 (~500 Synthea now — this slice is its only consumer, deferred from S1), GD10 (native Canvas scatter), GD5 (Director routing/scope). **Blocked by S1 only — parallelizable with S2/S3.**
+
+**Goal:** The Director's entry narrative (W02). On login a Director lands on a Population Dashboard: ~500 patients as a risk scatter (risk × urgency), a critical-zone count, a projected cost-avoidance figure, and team KPIs — all from a **population aggregate API over HAPI**. Clicking a cluster drills to a filtered patient list, then a patient detail view.
+
+**Architecture:** This slice finally runs the **Synthea import deferred from S1** (~500 diabetes/CHF/depression patients, bulk `$batch` into the same HAPI). Backend gains a `population/` aggregate service: `getPopulationScatter()` (risk score + urgency per patient, from RiskAssessment + condition/encounter recency), `getPopulationSummary()` (critical-zone count, computed cost-avoidance, team KPIs) — all through the audited FHIR client. Frontend adds W02 as the **Director home route** (role→home already exists from S1's `RoleGuard`; add the Director branch) with a native Canvas scatter and drill-in navigation to a filtered `PatientPanel`-style list → existing `PatientDetail`.
+
+**Tech Stack (delta):** Synthea generation + `$batch` import script (extends `scripts/import-fhir.ts`) · `population/` aggregate module · one Canvas 2D scatter component (no chart library, GD10) · Director route branch in `App.tsx`/`RoleGuard`.
+
+**Ponytail pass applied:** aggregate over HAPI search/`_count` + a bounded fan-out, not a precomputed analytics store; cost-avoidance is a **documented transparent formula** over real counts (risk-weighted avoided-readmission × unit cost), computed not hardcoded, with the formula recorded — not an ML model; one scatter component reusing the S4 canvas patterns; drill-in reuses the existing panel/detail screens with a filter param, not new screens; Synthea import is a script run, not a pipeline.
+
+### Phase A — Population data + aggregate API (backend, test-first)
+
+- [ ] **A1. Synthea import (~500).** Generate the diabetes+CHF+depression cohort and bulk-import via `$batch` into the same HAPI, alongside the curated hero bundles. Extend the existing import script; idempotent/re-runnable.
+  - *ponytail:* the population's **only** consumer is this dashboard (why S1 skipped it); generate once, commit the seed or the generation command.
+  - *Verify:* HAPI holds ~500 patients with RiskAssessment + demographics; hero patients still resolve.
+
+- [ ] **A2. Population aggregate service (audited).** `getPopulationScatter(actor)` → per-patient `{id, riskScore, urgency, x, y}`; `getPopulationSummary(actor)` → `{criticalZoneCount, projectedCostAvoidance, teamKpis}`. Director-scoped (aggregate). Cost-avoidance from a **recorded formula** over real risk counts. Routes `GET /api/population/scatter`, `GET /api/population/summary`.
+  - *Domain rule:* critical-zone count + cost-avoidance computed from patient data, not hardcoded (S5 acceptance, GD12 spirit); every read audited.
+  - *Test (Supertest vs test HAPI):* scatter returns ~500 points over seeded data; summary counts match the seeded critical cohort; the cost formula is asserted against a fixed small fixture.
+
+### Phase B — Director routing + W02 dashboard (frontend, mockup fidelity)
+
+- [ ] **B1. Director home route.** Extend role→home so Director lands on `/population` (not the Coordinator `/panel`); guard it Director-only. *Story 1.*
+  - *Domain rule:* home screen derived from role, not user-chosen (GD5).
+  - *Test (Vitest):* Director → `/population`; Coordinator still → `/panel`.
+
+- [ ] **B2. W02 Population Dashboard (`reference-materials/caresync-population.html`, `#scatter` canvas).** Native Canvas risk scatter (risk × urgency), critical-zone count tile, cost-avoidance tile, team KPI tiles — from A2. Port design tokens/structure per the mockup (`html-mockup-fidelity`, ≥80%).
+  - *Domain rule:* native Canvas, no chart library (GD10).
+  - *Test (Vitest, mocked API):* renders the summary tiles from data; scatter receives the points.
+
+- [ ] **B3. Drill-in.** Click a scatter cluster → filtered patient list → `PatientDetail`. Reuse the existing list/detail screens with a filter param.
+  - *Verify:* cluster → filtered list → detail navigation works (S5 acceptance).
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (population aggregates) + `npm run test:web` green.
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Director login → W02 renders scatter + computed tiles → drill cluster → filtered list → open Maria.
+
+### Rollback / safety
+Synthea data lives only in the disposable HAPI (`docker compose down -v` resets). Aggregates are read-only. Cost-avoidance formula is documented in the slice notes so the number is defensible/honest (not a magic figure).
+
+### Definition of done (S5) — maps to `issues.md`
+- Director login routes to W02 (B1).
+- Scatter renders ~500 patients from real HAPI-derived aggregates, native Canvas (A1, A2, B2).
+- Critical-zone count + cost-avoidance computed from data, not hardcoded (A2).
+- Drill-down cluster → filtered list → detail works (B3).
+- API-boundary tests for the population endpoints over seeded data (A2, C1).
+
+---
+
+## Iteration 6 — S6 Task assignment + real-time FHIR Subscription — 2026-07-04
+
+**Spec:** `prd.md` (stories 6, 18, 32) · **Slice:** S6 (`issues.md`) · **Decisions:** GD7 (a *real* FHIR Subscription rest-hook → backend webhook → client relay — not app-level SSE relabeled). **Blocked by S3.**
+
+**Goal:** The real-time loop. A Director assigns Maria's tasks to a specific Care Coordinator (Task updated in HAPI); a real **FHIR Subscription** (HAPI rest-hook on Task create/update) calls an API webhook, which relays the change to connected clients over SSE/websocket, so the Coordinator's view updates live with an assignment notification — no manual refresh.
+
+**Architecture:** Backend gains: an **assignment endpoint** (`PATCH`/update Task `owner`/`requester` in HAPI via the audited write client from S3), a **Subscription bootstrap** that creates the HAPI `Subscription` resource (rest-hook targeting our webhook) at startup (idempotent), a **webhook receiver** (`POST /api/fhir/subscription-hook`) that HAPI calls on Task changes, and a **client relay** — a `GET /api/events` SSE endpoint holding open connections, keyed by user, that the webhook fans out to. Frontend subscribes to `/api/events` and updates the task queue + shows a notification on relevant changes. The **web client is wired first** (GD7); mobile subscribes once GD4 resolves (S7).
+
+**Tech Stack (delta):** HAPI `Subscription` (rest-hook, `Task?...` criteria) · webhook receiver route · an in-process SSE hub (`Map<userId, res[]>`) for relay · client `EventSource`/`fetch`-stream consumer for `/api/events`.
+
+**Ponytail pass applied:** relay is an **in-process connection map**, not Redis/pub-sub (single API process in this POC); the Subscription is created once at boot (idempotent), not managed via UI; assignment is a Task field update, not a workflow engine; notification is a client-side toast off the relayed event, no notification table; reuse the audited write client from S3 — no new FHIR plumbing.
+
+### Phase A — Assignment + Subscription + relay (backend, test-first)
+
+- [ ] **A1. Task assignment endpoint (audited).** `PATCH /api/tasks/:id/assign { coordinatorId }` → update the FHIR Task `owner` in HAPI via the S3 audited write client. Director-scoped.
+  - *Domain rule:* Director assigns a patient's tasks to a Coordinator (story 6); write audited.
+  - *Test (Supertest vs test HAPI):* assignment sets Task.owner; reflected on read; audit row written.
+
+- [ ] **A2. FHIR Subscription bootstrap.** At boot, idempotently ensure a HAPI `Subscription` (rest-hook, criteria on Task create/update) pointing at our webhook URL. Record the honest-staging status if HAPI's rest-hook delivery needs config.
+  - *Domain rule:* a real FHIR Subscription exists on HAPI with a rest-hook on Task changes (S6 acceptance, GD7).
+  - *Test:* the Subscription resource exists in HAPI after boot with the expected criteria + endpoint.
+
+- [ ] **A3. Webhook receiver + relay hub.** `POST /api/fhir/subscription-hook` (HAPI → us) resolves the changed Task and fans it out over an in-process SSE hub to the affected user's `/api/events` connections. `GET /api/events` (auth'd) registers a connection.
+  - *ponytail:* in-process `Map<userId, res[]>` hub — no external broker; **reuse the existing `writeSseEvent` helper from `routes/analysis.ts`** for framing, don't re-author SSE plumbing.
+  - *Test (integration):* simulate a HAPI hook POST → an event is delivered to a registered `/api/events` connection for the assigned Coordinator (asserts the webhook→relay path).
+
+### Phase B — Live client update (frontend)
+
+- [ ] **B1. Client event subscription + live queue update + notification.** Subscribe to `/api/events`; on a relevant Task change, update the Coordinator's queue in place and show an assignment notification. No manual refresh.
+  - *Domain rule:* Coordinator notified when a Director assigns them a patient (story 18); queue updates live (S6 acceptance).
+  - *Test (Vitest, mocked stream):* a relayed assignment event updates the queue and shows a notification.
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (assignment + webhook→relay integration) + `npm run test:web`.
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Director assigns Maria's task → the Subscription fires → the Coordinator's view updates live + notification appears (visible without refresh). Confirm the Subscription firing is visible in logs/network.
+
+### Rollback / safety
+Subscription + Tasks live in the disposable HAPI. The relay hub is in-memory (drops on restart, reconnect re-establishes). Assignment writes are audited and reversible. If HAPI rest-hook delivery can't be configured in the stock image, record it in `plan.md` §3 honest-staging (same class of note as SMART) — do not claim live Subscription delivery it doesn't do.
+
+### Definition of done (S6) — maps to `issues.md`
+- A FHIR Subscription with a Task rest-hook exists on HAPI (A2).
+- Assigning a task updates the FHIR Task and fires the Subscription to the webhook (A1, A2, visible in logs).
+- The webhook relays to the client; the queue updates live with a notification (A3, B1).
+- API-boundary test for assignment + integration test for webhook→relay (C1); E2E (C2).
+
+---
+
+## Iteration 7 — S7 Role-filtered task queue + task actions — 2026-07-04
+
+**Spec:** `prd.md` (stories 24, 25, 27–29, 31) · **Slice:** S7 (M02/M03 + W13) · **Decisions:** GD4 (**mobile-stack decision — resolve before starting**; recommendation on record: PWA/responsive web), GD5 (role filtering). **Blocked by S3 + the GD4 decision.**
+
+**Goal:** The queue and its actions, built responsive per GD4. The queue **filters by role** — a Social Worker sees only SDOH-domain tasks, a Coordinator sees all. Opening a task shows the justifying patient context + citations; the user can **Complete / Defer / Escalate** (and Call), each PATCHing the FHIR Task status in HAPI and syncing back. Completing on the mobile-shaped view syncs to web via the S6 relay.
+
+**Pre-work (gate):** **Record the GD4 mobile-stack decision** (`plan.md` §8 / a short ADR) before implementation — recommendation is PWA/responsive web (one codebase, phone-frame demo). This slice assumes that unless overridden.
+
+**Architecture:** Backend gains a **role-filtered task listing** (`GET /api/tasks?role-scoped` — Social Worker → SDOH-domain Tasks only via the S1 scope map + Task category, Coordinator → all) and **status-transition endpoints** (`PATCH /api/tasks/:id/status` for complete/defer/escalate) on the audited write client. Frontend builds the M02 **task queue** and M03 **task detail** as responsive views (`reference-materials/caresync-mobile.html`), plus the W13 Task Management Center on web; status changes reflect back and, via the S6 relay, cross-surface (mobile→web).
+
+**Tech Stack (delta):** role-filtered Task query (scope map + Task.category) · Task status PATCH endpoints · responsive/PWA views (M02/M03) reusing the design system · reuses the S6 relay for cross-surface sync.
+
+**Ponytail pass applied:** filtering is the S1 role→domain scope map applied to Task.category — not a new permission system; complete/defer/escalate are **Task.status/businessStatus updates**, not a state-machine service; one responsive codebase (PWA) per the GD4 recommendation — no React Native toolchain unless the decision overrides; cross-surface sync **reuses the S6 relay** (no new channel); "Call" is a `tel:` link, not telephony integration.
+
+### Phase A — Role-filtered listing + transitions (backend, test-first)
+
+- [ ] **A1. Role-filtered task listing.** `GET /api/tasks` scoped by role: Social Worker → SDOH-domain Tasks only (scope map + Task.category), Coordinator → all. Audited.
+  - *Domain rule:* Social Worker sees only SDOH-domain tasks; Coordinator sees all (S7 acceptance, GD5).
+  - *Test (Supertest):* Social Worker listing excludes non-SDOH Tasks; Coordinator sees all types.
+
+- [ ] **A2. Status-transition endpoints (audited).** `PATCH /api/tasks/:id/status` handling complete/defer/escalate → FHIR Task status/businessStatus in HAPI via the S3 write client.
+  - *Domain rule:* transitions PATCH the FHIR Task status and reflect back (S7 acceptance); each write audited.
+  - *Test (Supertest vs test HAPI):* each transition sets the expected FHIR status; reflected on read; audit row written.
+
+### Phase B — M02 queue + M03 detail + W13 (frontend, mockup fidelity)
+
+- [ ] **B1. M02 Task Queue (responsive, `reference-materials/caresync-mobile.html`).** Role-filtered queue with priority sort + due dates; phone-frame responsive per GD4. *Stories 24, 27.*
+- [ ] **B2. M03 Task Detail + actions.** Justifying patient context + citations; Complete/Defer/Escalate wired to A2; Call as `tel:`. *Stories 28, 29, 31.*
+  - *Domain rule:* task detail shows justifying context + citations (S7 acceptance).
+- [ ] **B3. W13 Task Management Center (web) + cross-surface sync.** Web queue view; completing on the mobile-shaped view syncs to web via the S6 relay.
+  - *Test (Vitest):* role-filtered rendering; a status action calls the transition; a relayed change updates the other surface.
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (role listing + transitions) + `npm run test:web`.
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Social Worker mobile queue (SDOH-only) → open task → mark done → syncs to web (via S6). Coordinator sees all types.
+
+### Rollback / safety
+Task writes audited + reversible via HAPI reset. The GD4 decision is recorded before code so the stack isn't relitigated mid-slice. Cross-surface sync degrades to manual refresh if the relay is down (honest).
+
+### Definition of done (S7) — maps to `issues.md`
+- GD4 mobile-stack decision recorded before implementation (pre-work gate).
+- Social Worker queue SDOH-only; Coordinator sees all (A1).
+- Task detail shows justifying context + citations (B2).
+- Complete/Defer/Escalate PATCH FHIR status and reflect back (A2, B2).
+- Mobile completion syncs to web via S6 relay (B3, C2).
+- API-boundary tests for listing + each transition (A1, A2).
+
+---
+
+## Iteration 8 — S8 AI Governance & audit dashboard (W06) — 2026-07-04
+
+**Spec:** `prd.md` (stories 11–15) · **Slice:** S8 (W06) · **Decisions:** GD12 (**demographic parity computed from real Synthea demographics**, not static), builds on the S1 audit spine + S4 cached analyses. **Blocked by S3** (needs analyses to govern); parity needs S5's Synthea population.
+
+**Goal:** The trust story (W06). A governance view showing: the audit trail of every FHIR read/write (from the S1 `audit_log`) with timestamp + user; model version + timestamp per analysis; confidence distribution across the analyzed cohort; and **demographic parity metrics computed from real Synthea demographics** (risk by age/sex/race/ethnicity). Includes a **graceful placeholder tile for the S9 eval headline**.
+
+**Architecture:** Backend gains a `governance/` (or `audit/`) aggregate module: `getAuditTrail()` (page the S1 `audit_log`), `getModelPerformance()` (model version/timestamp + confidence distribution derived from S4 cached analyses), `getParityMetrics()` (join cached risk scores to Synthea demographics, stratify — computed, GD12). Routes under `GET /api/governance/*`. Frontend ports W06 (`reference-materials/caresync-governance.html`) with its `#confChart` + `#radarChart` canvases (native, GD10), the audit table, and an **eval tile that renders a graceful empty/loading state** until S9's JSON lands.
+
+**Tech Stack (delta):** `governance/` aggregate over `audit_log` + `analysis_cache` + HAPI demographics · two native Canvas charts (confidence dist + parity radar, GD10) · W06 port.
+
+**Ponytail pass applied:** read straight from the **existing** `audit_log` + `analysis_cache` — no new governance store; parity is a stratified aggregate query, not a fairness ML library; the eval tile reads the S9 JSON summary if present else renders empty — no coupling that blocks S8 on S9; two canvases reuse the GD10 pattern.
+
+### Phase A — Governance aggregates (backend, test-first)
+
+- [ ] **A1. Audit trail endpoint.** `GET /api/governance/audit` paging the S1 `audit_log` (ts, actor, action, resource, outcome).
+  - *Domain rule:* live audit trail of every FHIR read/write with timestamp + user (story 15); reuses the S1 spine.
+  - *Test (Supertest):* after some reads/writes, the trail lists them with actor + timestamp.
+
+- [ ] **A2. Model performance + confidence distribution.** `GET /api/governance/model` → model version + timestamp per analysis and a confidence distribution derived from S4 cached agent outputs.
+  - *Domain rule:* each analysis shows model version + timestamp (story 12); confidence distribution derived from actual outputs (S8 acceptance).
+  - *Test:* distribution computed from seeded cache rows matches expected buckets.
+
+- [ ] **A3. Demographic parity (computed — GD12).** `GET /api/governance/parity` → risk scores stratified by age/sex/race/ethnicity, joining cached analyses to real Synthea demographics from HAPI.
+  - *Domain rule:* parity computed from real Synthea demographics, not static (GD12, story 14).
+  - *Test (Supertest vs test HAPI):* strata reflect the seeded demographics; a known-imbalanced fixture yields the expected disparity direction.
+
+### Phase B — W06 Governance view (frontend, mockup fidelity)
+
+- [ ] **B1. W06 port (`reference-materials/caresync-governance.html`).** Audit trail table, Model Performance (`#confChart`), Demographic Equity Monitor (`#radarChart`) — native Canvas (GD10) — from A1–A3. ≥80% fidelity.
+- [ ] **B2. Eval headline tile (graceful placeholder).** Reads the S9 JSON summary if present, else an empty/loading state.
+  - *Domain rule:* eval tile renders graceful empty/loading until S9 provides data (S8 acceptance) — honest staging.
+  - *Test (Vitest):* renders parity/confidence/audit from data; eval tile shows empty state with no S9 data and the headline once present.
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (audit/model/parity) + `npm run test:web`.
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Director → W06 → audit rows, model version, confidence chart, parity radar all render from real data; eval tile shows its empty state.
+
+### Rollback / safety
+All reads over existing SQLite + HAPI — no new writable state. Parity/confidence are computed at request time (no cache to invalidate). The eval tile never fabricates numbers (honest staging).
+
+### Definition of done (S8) — maps to `issues.md`
+- Audit trail lists real logged reads/writes with timestamp + user (A1).
+- Each analysis shows model version + timestamp (A2).
+- Confidence distribution derived from actual agent outputs (A2).
+- Parity metrics computed from Synthea demographics, not static (A3).
+- Eval tile renders graceful empty/loading until S9 (B2).
+- API-boundary tests for audit/parity endpoints (A1, A3).
+
+---
+
+## Iteration 9 — S9 Evaluation harness + report — 2026-07-04
+
+**Spec:** `prd.md` (story 16) · **Slice:** S9 (Seam 4) · **Decisions:** GD8 (harness clinician-agnostic; ships **dev-labeled ~P6 4** with a clinician-override slot to 5; error analysis mandatory). **Blocked by S3.**
+
+**Goal:** The P6 lever. A runnable `npm run eval` loads the labeled patients (~5 curated hero + ~10 Synthea), runs the four agents over each, and computes sensitivity/specificity/PPV for Care Gap + Risk, an agreement rate for SDOH, and qualitative notes for Action Planner. It emits a methodology report **including an error analysis** and a **JSON summary feeding the S8 tile**.
+
+**Architecture:** New `eval/` (or `scripts/eval.ts`) + a committed `data/eval/labels.json` (ground truth, rows structured for later clinician override). The harness: load labeled patients from HAPI → run the four agents (live or cached) → compare findings vs labels → compute per-agent metrics + error analysis → write `docs/eval-report.md` + a JSON summary. The **metric computation is a pure function** isolated as **Seam 4**, tested against a fixed label fixture with known expected output.
+
+**Tech Stack (delta):** `data/eval/labels.json` · `scripts/eval.ts` (`npm run eval`) · a pure `computeMetrics(labels, findings)` module (Seam 4) · reuses the S3 orchestrator (live or S4 cache).
+
+**Ponytail pass applied:** labels are one committed JSON file (clinician-overridable rows), not a labeling app; metrics are one pure function (Seam 4) — the harness is glue around it; reuse the S3 orchestrator + S4 cache (no eval-only agent path); report is a generated Markdown file, not a dashboard; ships honest dev-labeled with the upgrade slot per GD8.
+
+### Phase A — Labels + metric core (test-first)
+
+- [ ] **A1. Committed label file.** `data/eval/labels.json` — ground truth for ~5 hero + ~10 Synthea, rows structured so a clinician can review/override the Synthea rows later (GD8).
+  - *Domain rule:* label file holds ground truth with clinician-overridable rows (S9 acceptance).
+
+- [ ] **A2. Metric computation — Seam 4 (pure, TDD).** `computeMetrics(labels, findings)` → sensitivity/specificity/PPV (Care Gap + Risk), agreement (SDOH), qualitative notes (Action Planner).
+  - *Domain rule:* per-agent metrics per GD8; Action Planner is qualitative (synthesis, not classification).
+  - *Test (Seam 4):* against a fixed label + findings fixture, the metrics match a known expected output exactly.
+
+### Phase B — Harness + report
+
+- [ ] **B1. `npm run eval` harness.** Load labeled patients from HAPI → run the four agents (live or cached) over each → `computeMetrics` → write `docs/eval-report.md` (**with a mandatory error-analysis section**: misses + false positives) + a JSON summary.
+  - *Domain rule:* report includes explicit error analysis (S9 acceptance, GD8 — this is the 4→5 lever); JSON summary consumed by the S8 tile.
+  - *Verify:* `npm run eval` produces the report + JSON; the S8 eval tile renders the headline from it.
+
+### Phase C — Verification
+- [ ] **C1.** Seam 4 unit test green; one full `npm run eval` run committed as evidence (labeled *dev-labeled baseline*).
+- [ ] **C2.** The S8 governance eval tile consumes the produced JSON (cross-slice check).
+
+### Rollback / safety
+Read-only over HAPI + labels; outputs are generated files (`docs/eval-report.md` + JSON), regenerable. Ships explicitly as a **dev-labeled ~P6 4** baseline; clinician override of the Synthea rows upgrades to 5 with no code change (GD8).
+
+### Definition of done (S9) — maps to `issues.md`
+- Committed label file with clinician-overridable rows (A1).
+- `npm run eval` runs agents over all labeled patients + computes per-agent metrics (A2, B1).
+- Report includes an explicit error-analysis section (B1).
+- JSON summary produced + consumed by the S8 tile (B1, C2).
+- Metric computation tested against a fixed fixture with known output — Seam 4 (A2).
+
+---
+
+## Iteration 10 — S10 CDS Hooks patient-view service — 2026-07-04
+
+**Spec:** `prd.md` (story 35) · **Slice:** S10 · **Decisions:** GD6 (a *real* patient-view CDS Hooks service, demoable via the public CDS Hooks sandbox — the fifth load-bearing standard). **Blocked by S3.**
+
+**Goal:** A real patient-view **CDS Hooks** service that, given a patient context, reads the HAPI bundle, runs (or reuses cached) agent findings, and returns them as **CDS cards** — demoable by pointing the public CDS Hooks sandbox at the service + HAPI.
+
+**Architecture:** New `cds-hooks/` module exposing the two spec endpoints: `GET /cds-services` (discovery) and `POST /cds-services/caresync-patient-view` (the patient-view service). The service reuses the **S4 cached analysis** (or triggers the S3 orchestrator) for the patient in context and maps validated findings → CDS Hooks `cards` (summary, indicator, detail, source, each carrying its FHIR citation). CORS-open enough for the public sandbox to reach it.
+
+**Tech Stack (delta):** CDS Hooks 1.0/2.0 discovery + patient-view request/response shapes · reuses S3 orchestrator + S4 cache + S2 citation guard · sandbox-reachable CORS.
+
+**Ponytail pass applied:** one discovery + one service endpoint (patient-view only — no order-select/sign), reusing the existing analysis path — no CDS-specific agent logic; cards are a **pure mapping** of already-validated findings; prefer cached analysis for demo determinism (GD2); no auth beyond what the sandbox needs (documented honest-staging).
+
+### Phase A — CDS Hooks service (backend, test-first)
+
+- [ ] **A1. Discovery endpoint.** `GET /cds-services` returning the patient-view service descriptor (id, hook, title, description, prefetch).
+  - *Domain rule:* exposes a CDS Hooks discovery endpoint (S10 acceptance, GD6).
+  - *Test:* discovery response is well-formed and lists the patient-view service.
+
+- [ ] **A2. Patient-view service + card mapping (pure).** `POST /cds-services/caresync-patient-view` → resolve the patient, reuse cached (or run) analysis, map **validated** findings → CDS cards carrying their FHIR citations. Card mapping is a pure, tested function.
+  - *Domain rule:* returns well-formed CDS cards carrying agent findings + FHIR citations (S10 acceptance); citations already validated (GD11).
+  - *Test:* for the hero patient, the service returns cards with the expected findings + resolvable citations; card mapping unit-tested against a canned analysis.
+
+### Phase B — Sandbox demo
+
+- [ ] **B1. Public sandbox wiring.** CORS/config so the public CDS Hooks sandbox can hit the running service + HAPI; document the sandbox URL/steps.
+  - *Verify:* a card fires in the public CDS Hooks sandbox against the running service (labeled evidence).
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (discovery + card generation) green.
+- [ ] **C2.** Sandbox smoke: a card renders in the public sandbox for the hero patient (evidence recorded, labeled *target-environment*).
+
+### Rollback / safety
+Read-only/derived — no new writable state. The sandbox is external: record what it exercised vs local. If the public sandbox can't reach a local service in the demo network, record the honest-staging limitation (screenshot/recorded fallback per GD2).
+
+### Definition of done (S10) — maps to `issues.md`
+- Discovery endpoint + patient-view service endpoint exist (A1, A2).
+- Patient-view hook returns well-formed cards with findings + FHIR citations (A2).
+- A card fires in the public sandbox against the running service (B1, C2).
+- Tests for discovery + card generation for the hero patient (A1, A2, C1).
+
+---
+
+## Iteration 11 — S11 Demo-supporting + shell screens — 2026-07-04
+
+**Spec:** `prd.md` (stories 8, 9, 26, 30; GD9 tiers) · **Slice:** S11 · **Decisions:** GD9 (three screen tiers), GD10 (design-system fidelity), honest staging (no placeholder-as-real). **Blocked by S5 + S7.**
+
+**Goal:** Breadth once the design system is established. Build the **demo-supporting tier** to designed/partial depth — SDOH resource directory + referral (M05), Quality/HEDIS (W05/W07), Team performance (W04), Patient quick profile (M04), Today/Schedule (M08), Care Plan builder (W14) — and **navigation-only shells** for the remaining screens (W08–W11, W13, W15, W16, M06, M07, M09, M10) with honest placeholder content. Scope flexes to remaining capacity; the six demo-critical screens keep priority.
+
+**Architecture:** Mostly frontend against the established design system + existing aggregate APIs, with two small real backends: **SDOH referral** creates a FHIR `ServiceRequest` (audited write, S3 client); **Quality/HEDIS** derives measure progress + incentive dollars from FHIR data (small `quality/` aggregate). Shells are routed `ComingSoon`-style pages with consistent styling and **explicitly-staged** placeholder content (never presented as functional). Reference mockups: `caresync-sdoh-mobile.html`, `caresync-quality-roi.html` (`#hedisChart`/`#trendChart`/`#donutChart`).
+
+**Tech Stack (delta):** FHIR `ServiceRequest` write (referral) · small `quality/` HEDIS aggregate · native Canvas for quality charts (GD10) · reuse `ComingSoon` shell pattern + design tokens.
+
+**Ponytail pass applied:** demo-supporting screens to **partial** depth only (GD9) — not full features; shells reuse the existing `ComingSoon` component, not bespoke pages; referral is one `ServiceRequest` write reusing the S3 client; HEDIS is a derived aggregate, not a measure engine; **capacity-flexed** — demo-critical screens always win; honest staging enforced (no fake-functional content).
+
+### Phase A — Demo-supporting screens (partial depth)
+
+- [ ] **A1. SDOH resource directory + referral (M05, `caresync-sdoh-mobile.html`).** List community resources by category (transportation/food/housing/mental health); a referral creates a FHIR `ServiceRequest` (audited).
+  - *Domain rule:* referral creates a FHIR ServiceRequest (S11 acceptance, story 30); write audited.
+  - *Test (Supertest):* referral POSTs a resolvable ServiceRequest; (Vitest) directory renders by category.
+- [ ] **A2. Quality/HEDIS view (W05/W07, `caresync-quality-roi.html`).** Measure progress + incentive dollars at stake, derived from FHIR data; native Canvas charts (GD10). *Story 9.*
+  - *Test:* aggregate computes measure progress over seeded data; view renders it.
+- [ ] **A3. Team performance (W04).** Coordinator workload + completion rates from Task/assignment data. *Story 8.*
+- [ ] **A4. Remaining supporting screens as capacity allows.** Patient quick profile (M04), Today/Schedule (M08), Care Plan builder (W14 — FHIR CarePlan, story 26) to partial depth.
+  - *ponytail:* build in priority order; stop at capacity, record what's partial (honest staging).
+
+### Phase B — Shell screens
+
+- [ ] **B1. Navigation-only shells.** W08, W09, W10, W11, W13, W15, W16, M06, M07, M09, M10 as styled placeholder pages in navigation.
+  - *ponytail:* **one `ComingSoon` component driven by a route→title table** (the S1 `ComingSoon` page already exists) — 11 rows of data, not 11 files.
+  - *Domain rule:* no shell presents placeholder data as real/functional (S11 acceptance — honest staging, gate G4).
+  - *Test (Vitest):* each shell route renders with consistent styling + an explicit "coming soon / not yet functional" treatment.
+
+### Phase C — Verification
+- [ ] **C1.** `npm run test:api` (referral + HEDIS aggregate) + `npm run test:web` (screens/shells).
+- [ ] **C2. Frontend E2E (`frontend-e2e-verification`)** for the demo-supporting screens that carry real behavior (SDOH referral, Quality view render). Shells covered by render tests.
+
+### Rollback / safety
+ServiceRequest writes audited + HAPI-reversible. Shells are inert. Honest-staging is the safety property here: partial/placeholder content is explicitly labeled so the demo never overclaims (G4).
+
+### Definition of done (S11) — maps to `issues.md`
+- SDOH directory lists resources by category; referral creates a ServiceRequest (A1).
+- Quality/HEDIS shows measure progress + incentive dollars from FHIR data (A2).
+- Team performance shows workload + completion rates (A3).
+- Shell screens exist in nav with consistent styling + placeholder content (B1).
+- No shell presents placeholder data as real (B1 — honest staging).
+
+---
+
+## Iteration 12 — S12 Demo hardening: E2E flows, fallback video, judge deck — 2026-07-04
+
+**Spec:** `prd.md` (stories 37 + demo narrative) · **Slice:** S12 (Seam 3) · **Decisions:** GD2 (demo reliability: cache + live + recorded fallback is first-class), G4 (honest-staging deck). **Blocked by S4, S5, S6, S7, S8, S9.**
+
+**Goal:** The final safety net. Automated **Playwright E2E tests for the three demo flows** (Seam 3) exercise the full stack; a **pre-recorded 90-second demo video** is the out-of-band fallback (GD2); and the **judge slide deck** is assembled (reuse `reference-materials/caresync-pitch-deck.html`, updated to what actually shipped + the honest-staging matrix).
+
+**Architecture:** Consolidate the per-slice E2E specs into three **full-stack demo-flow suites** (Seam 3) run against the running stack: Director (login → population → drill Maria → assign), Coordinator (open patient → run analysis → findings stream → Tasks appear), Social Worker (mobile queue → open task → mark done → syncs back). Each flow is demoable **both live and via cached replay** (GD2). Capture the 90s video from a passing run; assemble the deck from the pitch mockup, reconciled against `plan.md` §3 standards matrix + the honest built/prototyped/envisioned staging.
+
+**Tech Stack (delta):** Playwright multi-flow E2E against the full stack · screen recording (video) · deck from `caresync-pitch-deck.html`.
+
+**Ponytail pass applied:** three flow suites (not exhaustive coverage) — these *are* the acceptance tests for the demo narrative; reuse the per-slice specs already written under `frontend-e2e-verification`; the deck reuses the existing pitch mockup, updated not rebuilt; video captured from a real passing run (not staged).
+
+### Phase A — E2E demo-flow suites (Seam 3)
+
+- [ ] **A1. Three full-stack flow suites.** Playwright, against the running stack, green:
+  - Director: login → population → drill into Maria → assign.
+  - Coordinator: open patient → run analysis → findings stream → Tasks appear.
+  - Social Worker: mobile queue → open task → mark done → syncs back (via S6).
+  - *Domain rule:* these are the demo acceptance tests (Seam 3).
+- [ ] **A2. Live + cached parity.** Each flow runs both live (fresh model run) and via cached replay (GD2) with the same UI treatment.
+  - *Verify:* both modes pass green.
+
+### Phase B — Fallback video + judge deck
+
+- [ ] **B1. 90-second fallback video.** Capture from a passing run; matches the live flow (GD2 out-of-band fallback).
+- [ ] **B2. Judge deck.** Reuse `reference-materials/caresync-pitch-deck.html`; update to reflect **shipped** functionality + the built/prototyped/envisioned staging matrix (gate G4) — not the original pitch claims. Bundle the S9 eval report + the standards-conformance matrix.
+  - *Domain rule:* deck reflects shipped reality + honest staging (G4); submission bundles the eval report + standards matrix (S12 acceptance).
+
+### Phase C — Verification
+- [ ] **C1.** Playwright E2E suite for all three flows passes green against the running stack (both live + cached).
+- [ ] **C2.** Video exists + matches the live flow; deck + eval report + standards matrix assembled for submission.
+
+### Rollback / safety
+E2E runs against the disposable stack. The recorded video + cached replay are the belt-and-suspenders for a stage network failure (GD2). The deck is reconciled against `plan.md` §3 so no claim outruns what shipped (G4 honest staging).
+
+### Definition of done (S12) — maps to `issues.md`
+- Playwright E2E covers all three demo flows end-to-end and passes green (A1, C1).
+- The three flows are demoable both live and via cached replay (A2).
+- A 90-second fallback video exists and matches the live flow (B1).
+- The judge deck reflects shipped functionality + honest staging, not pitch claims (B2).
+- The submission bundles the eval report (S9) + the standards-conformance matrix (B2).
+
+---
+
+## Handoff note (S3–S12 planned 2026-07-04)
+
+Iterations 3–12 above are the **strong, ponytail-annotated plans** for the remaining slices, written straight from `issues.md` (S3–S12) and grounded in the S1/S2 code seams (`FhirReadService`, the defaulted-`runAgent` param on `createAnalysisRouter`, `AgentEvent`/`runRiskAgent`, `validateCitations` Seam 2, the audited `fetch`, `SmartTokenClient`, `streamAnalysis`, the `FeedBox`/`AgentGraph` W03 host, and the six mockups). They are **implementation-ready for any executor** (e.g. Codex/GPT‑5.5): each task carries its acceptance mapping, test seam, domain rule/decision citation, and rollback.
+
+**Per-slice activation:** `tasks/todo.md` holds the *one active slice* (currently S2). When starting a slice, mirror that iteration's checkboxes into `tasks/todo.md` (add `## Approved: yes` only by user approval), implement via `subagent-driven-development`, then `verification-before-completion` → `code-review`.
+
+**Dependency order (from `issues.md`):** S3→S4; S5 parallel off S1; S6/S8/S9/S10 off S3; S7 off S3 + the GD4 decision; S11 off S5+S7; S12 off S4/S5/S6/S7/S8/S9. Critical path: S1→S2→S3→(S6/S8/S9)→…→S12.

--- a/docs/plans/caresync-ai/issues.md
+++ b/docs/plans/caresync-ai/issues.md
@@ -45,16 +45,17 @@ determines both the landing screen and which FHIR scopes the API issues.
 
 ### What to build
 The core innovation, kept thin to one agent. On Maria's detail view, "Run Analysis"
-starts an analysis that dispatches the **Risk agent** (live Claude Sonnet 5,
-structured output) over her FHIR bundle. Its findings stream to a single feed box
-over SSE, word-by-word. Every `fhirResourceId` the agent emits is validated against
-the resource IDs actually present in the retrieved bundle; any citation not in the
-bundle is dropped/flagged before it reaches the UI. This establishes the SSE stream,
-the citation validator as an isolated pure module, and the reusable agent-service
-pattern.
+starts an analysis that dispatches the **Risk agent** (live model call,
+structured output — **OpenAI `gpt-5.5`**, revised 2026-07-04 from the original
+Claude Sonnet 5 plan; see `plan.md` GD13) over her FHIR bundle. Its findings stream
+to a single feed box over SSE, word-by-word. Every `fhirResourceId` the agent emits
+is validated against the resource IDs actually present in the retrieved bundle; any
+citation not in the bundle is dropped/flagged before it reaches the UI. This
+establishes the SSE stream, the citation validator as an isolated pure module, and
+the reusable agent-service pattern.
 
 ### Acceptance criteria
-- [ ] "Run Analysis" triggers a live Claude call producing structured Risk output (riskScore, riskLevel, flags with fhirResourceId, readmissionProbability).
+- [ ] "Run Analysis" triggers a live model call producing structured Risk output (riskScore, riskLevel, flags with fhirResourceId, readmissionProbability).
 - [ ] Findings stream to the client over SSE and render incrementally in one feed box.
 - [ ] The citation validator, given an agent output with one in-bundle citation and one fabricated ID, passes the valid one and drops/flags the fabricated one.
 - [ ] No finding reaches the UI citing a resource ID absent from the retrieved bundle.

--- a/docs/plans/caresync-ai/prd.md
+++ b/docs/plans/caresync-ai/prd.md
@@ -127,8 +127,9 @@ EHR/standalone launch is envisioned, not built.
 
 **Agent orchestration (GD2/GD11/GD13).** An Orchestrator dispatches four specialist
 agents in parallel over the patient's FHIR bundle, streaming findings to the client
-over SSE. Agents run on **Claude Sonnet 5 (`claude-sonnet-5`)** with structured
-output. The agent I/O contracts:
+over SSE. Agents run on **OpenAI `gpt-5.5`** (via the `openai` SDK Responses API)
+with structured output — provider **revised 2026-07-04** (see `plan.md` GD13;
+originally Claude Sonnet 5). The agent I/O contracts:
 
 - Risk: bundle (Condition, Observation, MedicationRequest, Encounter) →
   `{ riskScore, riskLevel, flags: [{type, finding, fhirResourceId, severity}], readmissionProbability }`
@@ -146,7 +147,7 @@ finding reaches the UI or becomes a Task. This is the core safety guarantee.
 
 **Analysis caching (GD2).** The last successful analysis per patient is persisted.
 Demo mode replays it deterministically; an explicit "live" trigger forces a fresh
-Claude run and re-caches. A pre-recorded video is the out-of-band fallback.
+model run and re-caches. A pre-recorded video is the out-of-band fallback.
 
 **FHIR data (GD3).** Maria Chen plus 1–2 backup hero patients are hand-authored as
 controlled FHIR R4 bundles (exact labs/conditions/SDOH); ~500 Synthea patients

--- a/docs/plans/caresync-ai/review.md
+++ b/docs/plans/caresync-ai/review.md
@@ -1,0 +1,59 @@
+# Code Review — CareSync AI, S2 (Single-agent analysis with citation enforcement)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S2 · **Date:** 2026-07-04
+> **Fixed point:** `main` (merge-base `30d7c0e`). Only one commit exists on this branch ahead of
+> `main` (`f6e7198`, docs-only); everything else reviewed here is uncommitted working-tree state
+> (tracked modifications + untracked new files per `git status`) — nothing below has landed yet.
+
+Two axes reviewed in parallel, independently, per the repo's `code-review` skill. Not merged or reranked — see that skill's "why two axes" note.
+
+## Standards
+
+**Hard violation — Duplicated Code / Data Clump: `PatientBundle` shape defined 3x independently.**
+`apps/api/src/fhir/client.ts:141-144` returns an inline anonymous type instead of an exported interface, unlike every other method in that file (`getPatient`/`getConditions`/`getTasks`/`getAssignedPanel`, which all return exported named interfaces reused by callers). `riskAgent.ts:24` and `analysis.ts:7` each hand-redeclare the identical shape. A future bundle-shape change means editing three files (Shotgun Surgery risk).
+
+**Hard violation — Duplicated Code: `AgentFlag` defined twice**, identically, in `riskAgent.ts:10-13` and `citationValidator.ts:1-4`, with no import between them — breaks the file's own single-source-of-truth pattern for domain types.
+
+**Judgement call — Primitive Obsession / loosened typing.** `resources: any[]` (`client.ts:144`, `riskAgent.ts:25`, `analysis.ts:7`) and an `as any` stream cast (`riskAgent.ts:104`) widen typing beyond the surrounding file's style. Reasonable given the OpenAI Responses API's untyped event stream; worth a follow-up type once the SDK's discriminated unions are confirmed usable.
+
+**Correctly matches existing convention (not a finding):** `analysis.ts`'s scope-guard try/catch mirrors `patients.ts` exactly; default-param DI (`runAgent`, `client`) matches `FhirReadService`'s constructor-injection style; web-side type exports follow the established pattern.
+
+**Minor:** `data-testid="risk-summary"` (`PatientDetail.tsx:161`) is the only `data-testid` in the web app (other tests query by role/text) — inconsistency, not a hard violation.
+
+## Spec
+
+**(a) Missing/partial:** All five `issues.md` S2 acceptance criteria are implemented and tested. One partial: GD13 (`plan.md`) calls for "structured outputs via `text.format`/tool calling," but `riskAgent.ts:39` sets `strict: false` on the `report_risk` tool — OpenAI won't schema-enforce the call, so a malformed `RiskOutput` could reach the unguarded `JSON.parse` (`riskAgent.ts:116`) with no fallback.
+
+**(b) Scope creep:** None significant. The `dotenv` → native `process.loadEnvFile` swap is necessary supporting infra for A1, not overreach.
+
+**(c) Implemented but wrong — two findings:**
+
+1. **Citation enforcement doesn't cover the narrated token stream.** GD11 (`plan.md`): "the backend validates every citation against the bundle and drops/flags any hallucinated ID before it reaches the UI" — described in the plan as the slice's non-negotiable core guarantee. `analysis.ts:47-49` streams `token` events (the model's free-text narration) straight to the client with **zero validation** — only the structured `flags` array passes through `validateCitations`. The prompt (`riskAgent.ts` `buildPrompt`) never constrains the model from mentioning a `ResourceType/id` in its prose narration. A hallucinated ID spoken in the narration reaches the UI untouched. The literal `issues.md` acceptance criteria ("no *finding* reaches the UI citing an absent ID") are satisfied — this gap is in the broader GD11 guarantee the plan documents, not the narrower literal wording.
+
+2. **The documented "unset key → graceful per-request error" claim is false.** `implementation-plan.md` Iteration 2 Rollback note: "Unset `OPENAI_API_KEY` to disable live analysis; the route degrades to an explicit error, not a fake result." In practice `export const openai = new OpenAI()` (`riskAgent.ts:5`) runs at **module import time** and throws synchronously with no key present. Since `index.ts` imports `createAnalysisRouter` (→ `riskAgent.ts`) unconditionally at startup, an unset key crashes the **whole API process at boot**, not just the analysis route per-request. `jest.setup.ts`'s placeholder-key workaround shows the authors were aware of the throw but didn't reconcile it with the rollback story.
+
+## Summary
+
+- **Standards:** 2 hard findings (duplicated `PatientBundle`/`AgentFlag` types), 1 judgement call (loosened typing), 1 minor (test-id inconsistency). Worst: the 3-way `PatientBundle` duplication — genuine Shotgun Surgery risk on the next bundle-shape change.
+- **Spec:** 2 "implemented but wrong" findings, 1 partial (unenforced schema strictness). Worst: **narrated-text citations bypass GD11's validation gate entirely** — this is the closest thing to a defect in the feature's actual safety guarantee, not just its literal test coverage.
+
+## Cross-reference with `verification.md`
+
+`verification.md` (written earlier this pass) independently found a third real gap not duplicated here: `analysis.ts`'s SSE streaming loop has no error handling around `runAgent`'s `for await` — an agent failure mid-stream hangs the client and, absent any process-level unhandled-rejection handler, can crash the API process. Combined with this review's finding (2) above (import-time crash on a missing key), `analysis.ts`/`riskAgent.ts` have two distinct process-crash risk vectors, both unexercised by current tests.
+
+## Post-review update — 2026-07-04
+
+**User decision: fix all three defects plus both Standards duplications before commit.** All fixed, test-first — see `implementation-plan.md` Iteration 2, "Post-review fixes" (E1–E4) for the detail per finding:
+
+- Standards duplication #1 (`PatientBundle` 3x) → fixed (E4): now exported once from `fhir/client.ts`.
+- Standards duplication #2 (`AgentFlag` 2x) → fixed (E4): now exported once from `citationValidator.ts`.
+- Spec finding "implemented but wrong" #1 (narration citations unvalidated) → fixed (E2): `redactUnvalidatedCitations` + `createNarrationBuffer`.
+- Spec finding "implemented but wrong" #2 (boot-time crash on missing key) → fixed (E3): lazy client construction.
+- Cross-referenced verification.md gap (SSE loop has no error handling) → fixed (E1): try/catch + `error` SSE event.
+- Not addressed (out of scope, low severity, no action needed): the `strict: false` tool-schema partial finding (Spec §a) and the loosened-typing/`data-testid` judgement calls (Standards) — left as-is, no functional risk.
+
+Re-verified: `npm run test:api` → 15 suites / 61 tests passing (12 new, covering all four fixes); build + lint clean.
+
+## Next step
+
+Run `finishing-a-development-branch` — both this review and `verification.md` are now resolved.

--- a/docs/plans/caresync-ai/verification.md
+++ b/docs/plans/caresync-ai/verification.md
@@ -1,0 +1,73 @@
+# Verification — CareSync AI, S2 (Single-agent analysis with citation enforcement)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S2 · **Date:** 2026-07-04
+> **Stage:** Phase 5 (`verification-before-completion`), run against the uncommitted S2 diff on
+> `feature/caresync-s2-single-agent-analysis`. Read `docs/plans/caresync-ai/implementation-plan.md`
+> Iteration 2 and `tasks/todo.md` for the plan this verifies against — not re-derived here.
+
+## 1. Fresh command evidence (this session, 2026-07-04)
+
+All commands re-run fresh in this session, not carried over from the prior session's notes.
+
+| Command | Result |
+|---|---|
+| `FHIR_BASE_URL=http://localhost:8080/fhir npm run test:api` | **15 suites / 49 tests passed** |
+| `npm run test:web` | **5 files / 14 tests passed** |
+| `npm run lint --workspace apps/api` | 0 errors, 2 pre-existing warnings (`riskAgent.test.ts` unused `_event`) |
+| `npm run lint --workspace apps/web` | 0 errors, 2 pre-existing warnings (`useAuth.tsx` fast-refresh) |
+| `npm run build --workspace apps/api` (`tsc`) | exit 0 |
+| `npm run build --workspace apps/web` (`tsc -b && vite build`) | exit 0 |
+
+Matches the prior session's D1 evidence exactly (49/49, 14/14) — no regression since the handoff was written. Docker `caresync-ui-hapi-fhir-1` was confirmed running before the API suite ran.
+
+Not re-run (per the handoff, doesn't need repeating since agent code hasn't changed): the live D3 OpenAI call and the Playwright E2E suite (`patient-analysis.spec.ts`). Both are already documented with dated evidence in `implementation-plan.md` Iteration 2, D2/D3.
+
+## 2. Definition-of-done check (S2 acceptance, `issues.md`)
+
+All 5 acceptance bullets confirmed against the actual code (not just the plan doc's claim):
+
+1. **Live call → structured Risk output** — `apps/api/src/agents/riskAgent.ts` `runRiskAgent`, `report_risk` tool schema requires `riskScore`/`riskLevel`/`flags`/`readmissionProbability`. Confirmed via D3 live evidence + `riskAgent.test.ts`.
+2. **SSE streaming, incremental render** — `routes/analysis.ts` streams `token` events then `finding`/`complete`; `apps/web/src/api/client.ts` `streamAnalysis` + `PatientDetail.tsx` render incrementally. Confirmed via `analysis.test.ts` and Playwright D2.
+3. **Citation validator passes valid, drops fabricated** — `citationValidator.ts` `validateCitations`, unit-tested with exactly this in/out-of-bundle pair (`citationValidator.test.ts`).
+4. **No out-of-bundle citation reaches the UI** — enforced in `routes/analysis.ts` (`validateCitations` gates every flag before `writeSseEvent(res, 'finding', ...)`); `analysis.test.ts` asserts the fabricated id never appears in `res.text`.
+5. **Unit + API-boundary test coverage** — present and green (see §1).
+
+No drift between what's claimed done and what the code does.
+
+## 3. Spec-drift check (issues.md / prd.md / plan.md vs. implementation-plan.md vs. code)
+
+- **`prd.md`'s uncommitted 4-line diff** (flagged by the prior handoff as "not reviewed, worth a glance"): reviewed. It's the GD13 provider-revision edit (Claude Sonnet 5 → OpenAI `gpt-5.5`, dated 2026-07-04) applied consistently to the agent-orchestration and caching sections. **Not drift** — it correctly reflects the same decision recorded in `plan.md` GD13 and `implementation-plan.md` Iteration 2.
+- **`issues.md` S2 section is stale** — its "What to build" and acceptance criterion #1 still read "live Claude Sonnet 5 call" / "live Claude call," with no note of the GD13 provider revision that `prd.md`, `plan.md`, and `implementation-plan.md` all carry. Functionally harmless (the actual implementation and its own plan/PRD are correct and consistent with each other), but `issues.md` is the acceptance-criteria source of truth per the ADLC chain and should say what actually shipped. **Recommend a one-line update to `issues.md`** noting the revision, same as the other three docs — low priority, doesn't block this gate.
+- **`implementation-plan.md` task A1 checkbox is unchecked** (`- [ ] **A1 (revised).**`) while `tasks/todo.md` shows it checked and the code (`riskAgent.ts` lines 1–8) confirms it's implemented exactly as described. Cosmetic doc inconsistency between the two plan artifacts, not a functional gap.
+- **Iteration 3–9 (S3–S9) content already drafted in `implementation-plan.md`**: confirmed present, per the prior handoff's flag. Not touched by this verification pass — out of scope for S2, and per the handoff, not yet an approved planning pass. Flagged again below for the user.
+
+## 4. Backend review pass (ahead of the formal `code-review` skill)
+
+Reviewed the full backend diff (`riskAgent.ts`, `citationValidator.ts`, `routes/analysis.ts`, `fhir/client.ts`'s `getPatientBundle`, `env.ts`) against this repo's existing conventions (`routes/patients.ts`, `fhir/client.ts`'s other methods).
+
+- `getPatientBundle` follows the exact existing audit/guard pattern (guard → fetch → audit-on-success only, consistent with every other method in `fhir/client.ts` — failed HAPI reads aren't audited anywhere in this codebase, not a new gap).
+- `citationValidator.ts` is a pure function, no I/O, matches its Seam 2 spec exactly.
+- **Finding — no error handling around the SSE streaming loop in `routes/analysis.ts`.** The bundle fetch (`getPatientBundle`) is wrapped in try/catch for `ScopeDeniedError`, but the subsequent `for await (const event of runAgent(bundle))` loop is not. `riskAgent.ts`'s `runRiskAgent` is documented and unit-tested (`riskAgent.test.ts`, "throws if the model never calls report_risk") to throw mid-generator — and any transient OpenAI network/rate-limit failure would throw the same way. Since `res.writeHead(200)` has already run by that point, a thrown error here means:
+  - the client's SSE connection hangs indefinitely — no `finding`, `complete`, or error event is ever sent, and the "Run Analysis" UI has no way to know the call failed;
+  - the rejected promise from the async Express route handler is unhandled (Express 4 does not catch async-handler rejections, and there's no `process.on('unhandledRejection', ...)` anywhere in `apps/api/src/index.ts`); under Node 22's default `--unhandled-rejections=throw`, this **crashes the whole API process** for every concurrent user, not just the one whose analysis call failed.
+  - This is a real gap in the branch's own diff (not inherited from S1's `patients.ts`, which at least try/catches its own FHIR calls, if not the equivalent unhandled-rejection risk on non-`ScopeDeniedError` errors — that part *is* a pre-existing, out-of-scope S1 pattern).
+  - **Not exercised by any existing evidence**: D1–D3 and the Playwright E2E all cover the success path only; nothing in `analysis.test.ts` feeds `runAgent` a stub that throws.
+  - **Recommendation:** wrap the streaming loop in try/catch, emit an `error` SSE event and call `res.end()` on failure, and add a Supertest case with a throwing stub agent (mirrors the existing `stubAgent` pattern in `analysis.test.ts`). Small, contained, test-first fix consistent with repo conventions — did not implement it in this verification pass so `code-review` and the user can weigh in on priority/timing first.
+
+## 5. Domain-term documentation check
+
+No `docs/agents/domain.md` exists yet — `implementation-plan.md`'s own header (line 13) already notes this and defers it to "before spec-heavy later slices." All S2-introduced domain terms (`AgentEvent`, `RiskOutput`, citation validator / Seam 2, `droppedCount`, `$everything`, `validIds`) are documented inline via "Domain rule:" / "Domain terms:" annotations in `implementation-plan.md` Iteration 2, and the GD13 provider decision is fully recorded in `plan.md`. Sufficient for this POC stage; no action needed.
+
+## 6. Gate outcome
+
+**PASS.** All fresh command evidence is green and matches the plan's claims (§1–2); the two low-priority doc-drift items (§3, `issues.md`'s stale "Claude" wording and the `implementation-plan.md` A1 checkbox) were fixed alongside the code fixes below.
+
+## 7. Post-review update — 2026-07-04
+
+`code-review` (see `review.md`) ran next and, combined with §4's finding here, surfaced three real defects (this SSE gap, plus two the Spec review caught: narration citations bypassing GD11, and a boot-time crash on a missing API key) and two Standards duplications. **User decision: fix all before commit.** All four fixed test-first — see `implementation-plan.md` Iteration 2, "Post-review fixes" (E1–E4) for the detail. Re-verified fresh after: `npm run test:api` → **15 suites / 61 tests passing** (up from 49), `npm run test:web` → 14/14 unchanged, both builds and lints clean. `git status`/diff reviewed — no other files touched beyond the four fix areas plus this doc set.
+
+**Still unresolved, carried forward:** Iteration 3–9 draft content in `implementation-plan.md` needs a decision from the user before anyone treats it as ready to implement — not addressed in this pass, out of scope for S2.
+
+## Next step
+
+`finishing-a-development-branch`, once `code-review`'s findings are also marked resolved in `review.md`.

--- a/docs/superpowers/specs/feature-caresync-s2-single-agent-analysis/2026-07-04-changelog.md
+++ b/docs/superpowers/specs/feature-caresync-s2-single-agent-analysis/2026-07-04-changelog.md
@@ -1,0 +1,81 @@
+# Changelog: S2 — Single-agent analysis with citation enforcement
+
+**Type:** Feature
+
+**Branch:** `feature/caresync-s2-single-agent-analysis`
+
+**Date:** 2026-07-04
+
+## Summary
+
+Added a live "Run Analysis" flow on the patient detail view: a Risk agent (OpenAI `gpt-5.5`) streams clinical reasoning and structured findings over SSE, with every FHIR citation — in both the structured output and the free-text narration — validated against the patient's retrieved bundle before it reaches the UI.
+
+## Changes Made
+
+### Backend — Risk agent + SSE route
+
+- **Before:** No agent capability existed; `PatientDetail` only read static FHIR data (name, conditions, tasks).
+- **After:** `POST /api/patients/:id/analysis` streams a live Risk agent run over SSE (`token`, `finding`, `complete`, `error` events), auditing the underlying `$everything` read.
+- **Files changed:** `apps/api/src/agents/riskAgent.ts`, `apps/api/src/routes/analysis.ts`, `apps/api/src/fhir/client.ts` (`getPatientBundle`), `apps/api/src/index.ts` (route wiring), `apps/api/src/env.ts` (new — loads `.env` before the agent module constructs its client).
+- **Key changes:** `runRiskAgent(bundle)` — an async generator calling the OpenAI Responses API with a `report_risk` function tool; `getPatientBundle` — one audited `Patient/{id}/$everything` read, deriving `validIds` directly from the returned resources so the citation-check set can't drift from the agent's actual input.
+
+### Backend — Citation enforcement (GD11, Seam 2)
+
+- **Before:** No citation-validation mechanism existed.
+- **After:** Every `fhirResourceId` the agent produces — whether in a structured `flag` or mentioned in free-text narration — is checked against the bundle; anything not present is dropped (flags) or redacted (narration) before the client ever sees it.
+- **Files changed:** `apps/api/src/agents/citationValidator.ts`.
+- **Key changes:** `validateCitations(flags, validIds)` partitions structured flags into valid/dropped. `redactUnvalidatedCitations(text, validIds)` and `createNarrationBuffer(validIds, lookahead)` extend the same guarantee to the streamed narration: the buffer holds back a small (96-char) trailing window so a `ResourceType/id` split across two token deltas is still whole before it's checked, trading a small bounded delay in the live-streaming effect for a real enforcement guarantee instead of buffering (and losing the live effect of) the whole narration.
+
+### Frontend — Run Analysis control + streaming feed
+
+- **Before:** `PatientDetail` had no analysis affordance; the other three feed boxes from the mockup didn't exist yet.
+- **After:** A "Run Analysis" control triggers the SSE call; narration streams incrementally into one Risk feed box with a blinking cursor, and validated findings render as FHIR citation chips (`Condition/…`, `Observation/…`) alongside the risk summary. The other three feed boxes render as honest idle placeholders (wired in S3).
+- **Files changed:** `apps/web/src/api/client.ts` (`streamAnalysis` — `fetch` + `ReadableStream`, parses SSE), `apps/web/src/pages/PatientDetail.tsx`, `apps/web/src/index.css`, `apps/web/vite.config.ts`.
+
+### Post-review fixes (same branch, before merge)
+
+`verification-before-completion` and `code-review` (run this session against the already-implemented S2 diff) found three real defects and two duplicated-type Standards findings, none exercised by the original success-path-only test evidence. All fixed test-first before commit:
+
+- **SSE error handling** — *Before:* an agent failure mid-stream (proven to happen when the model skips the tool call, or on any transient OpenAI failure) hung the client forever with no error event, and the unhandled promise rejection could crash the whole API process (no error handling existed around the streaming loop, and no process-level handler was registered). *After:* the loop is wrapped in try/catch; a failure emits an `error` SSE event and ends the response cleanly.
+- **Narration citation enforcement gap** — *Before:* only the structured `flags` array was validated; a hallucinated FHIR id mentioned in the model's free-text narration reached the UI untouched. *After:* `createNarrationBuffer` + `redactUnvalidatedCitations` cover the narration stream too (see above).
+- **Boot-time crash on missing API key** — *Before:* `export const openai = new OpenAI()` ran at module import time and threw synchronously with no key; since the route is imported unconditionally at API startup, an unset key crashed the *whole process at boot* — contradicting the documented "unset key degrades to a per-request error" rollback story. *After:* the client is built lazily on first use (`getOpenAiClient()`), so a missing key only fails the one request that needs it. The `jest.setup.ts` placeholder-key workaround for the old eager-throw is no longer needed and was deleted, along with its `jest.config.js` wiring.
+- **Duplicated types (Standards)** — *Before:* `PatientBundle` was independently redeclared in `fhir/client.ts`, `riskAgent.ts`, and `analysis.ts`; `AgentFlag` was redeclared in both `riskAgent.ts` and `citationValidator.ts`. *After:* each is exported once (`PatientBundle` from `fhir/client.ts`, `AgentFlag` from `citationValidator.ts`) and imported everywhere else.
+
+## Files Modified
+
+| File | Change Description |
+|------|---------------------|
+| `apps/api/src/agents/riskAgent.ts` | New — Risk agent (OpenAI `gpt-5.5`, Responses API, structured output), lazy client construction |
+| `apps/api/src/agents/citationValidator.ts` | New — Seam 2: `validateCitations`, `redactUnvalidatedCitations`, `createNarrationBuffer` |
+| `apps/api/src/routes/analysis.ts` | New — `POST /:id/analysis` SSE route, validation gate, error handling |
+| `apps/api/src/fhir/client.ts` | `getPatientBundle` (`$everything` + `validIds`), exports `PatientBundle` |
+| `apps/api/src/env.ts` | New — loads `.env` before agent modules construct clients |
+| `apps/api/src/index.ts` | Wires `createAnalysisRouter`; imports `./env` first |
+| `apps/web/src/api/client.ts` | `streamAnalysis` — SSE client over `fetch`/`ReadableStream` |
+| `apps/web/src/pages/PatientDetail.tsx` | Run Analysis control + Risk feed box, idle placeholders for S3 |
+| `apps/api/jest.config.js` | Removed the `setupFiles` entry (no longer needed after the lazy-client fix) |
+| `apps/api/jest.setup.ts` | Deleted — placeholder-key workaround no longer needed |
+| `docs/plans/caresync-ai/{implementation-plan,issues,prd}.md`, `plan.md`, `tasks/todo.md` | Plan/spec docs updated for GD13 (provider revision) and the post-review fixes |
+
+## Commits
+
+| Commit | Description |
+|--------|-------------|
+| `f6e7198` | docs(S2): add ponytail-simplified implementation plan + active checklist |
+| `5a898ba` | feat(S2): single-agent analysis with citation enforcement (implementation + post-review fixes) |
+
+## Testing & Verification
+
+**How to verify this works:**
+- `FHIR_BASE_URL=http://localhost:8080/fhir npm run test:api` — 15 suites / 61 tests
+- `npm run test:web` — 5 files / 14 tests
+- `npm run test:e2e` — 3 Playwright specs (login/panel, analysis streaming, social-worker denial)
+- `npm run build` + `npm run lint` for both `apps/api` and `apps/web`
+
+**Test results (this session, 2026-07-04):** all green — 61/61 API, 14/14 web, 3/3 E2E, both builds exit 0, both lints 0 errors (pre-existing warn-level warnings only). Full detail and live-model evidence (D1–D3, E1–E4) in `docs/plans/caresync-ai/implementation-plan.md` Iteration 2, and the gate write-ups in `docs/plans/caresync-ai/verification.md` and `review.md`.
+
+## Notes
+
+- **GD13 revision:** the agent provider was switched from the originally-planned Claude Sonnet 5 to OpenAI `gpt-5.5` because no Anthropic API key was available to prove the live-call verification step. User-approved straight substitution under the same `runRiskAgent`/`AgentEvent` contract — recorded in `plan.md` GD13.
+- **Known deferral, not a regression:** citation redaction in narration uses a 96-character lookahead heuristic (regex-based, bounded buffer) rather than buffering the entire response — a citation that happens to split across a boundary wider than 96 characters is a theoretical edge case not fully eliminated. Acceptable for this POC's threat model; documented in `citationValidator.ts`.
+- **Out of scope, flagged for the user, not addressed this session:** `implementation-plan.md` already contains drafted Iteration 3–9 (S3–S9) content that wasn't produced by an approved planning pass in either this or the prior session — needs a decision before anyone treats it as ready to implement. A separate, untracked `docs/plans/caresync-ai/review-s1.md` (a retroactive S1 code review, not authored by this session) also appeared mid-branch and was left untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.11.1",
         "cors": "^2.8.6",
-        "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "^9.0.3",
+        "openai": "^6.45.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
@@ -5289,18 +5289,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8756,6 +8744,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/plan.md
+++ b/plan.md
@@ -150,10 +150,20 @@ The 6 demo-critical screens are the non-negotiable core; everything else flexes.
 Demographic parity metrics on W06 (risk scores by age/sex/race/ethnicity) are
 **computed from real Synthea demographics**, not static display numbers.
 
-### GD13 — Agents on Claude Sonnet 5; testing stack (locked)
-- **Agent model:** **Claude Sonnet 5 (`claude-sonnet-5`)** — the current Sonnet
-  tier fits parallel multi-agent calls and the P7 cost story. (Consider Haiku 4.5
-  for the cheapest agents if latency/cost pressure appears.)
+### GD13 — Agents on Claude Sonnet 5; testing stack (locked; **provider revised 2026-07-04**)
+- **Agent model (original):** **Claude Sonnet 5 (`claude-sonnet-5`)** — the
+  current Sonnet tier fits parallel multi-agent calls and the P7 cost story.
+  (Consider Haiku 4.5 for the cheapest agents if latency/cost pressure appears.)
+- **Agent model (revised, S2):** No Anthropic API key was available to prove
+  the live-call verification step (D3) for S2. Rather than block the slice,
+  the agent provider was swapped to **OpenAI, `gpt-5.5`** (current flagship,
+  Responses API, structured outputs via `text.format`/tool calling) — a
+  straight substitution under the same `runRiskAgent`/`AgentEvent` contract,
+  not a dual-provider toggle. **This is a real, user-approved revision of a
+  previously "locked" decision, not a silent swap** — recorded here so later
+  slices (S3's three additional agents) build against OpenAI, not Anthropic.
+  Revisit if an Anthropic key becomes available and the team wants to switch
+  back or run both.
 - **Testing:** Vitest (web unit) · Jest + Supertest (API) · Playwright (E2E on
   the 3 demo flows). TDD per ADLC.
 
@@ -169,7 +179,7 @@ Browser (React + Vite + TS, Tailwind, Zustand, TanStack Query)
 Express API (TS)
   ├── auth/          JWT issue/verify, role → SMART scope map
   ├── fhir/          SMART Backend Services client → HAPI (client-credentials)
-  ├── agents/        Risk · CareGap · SDOH · ActionPlanner (Claude Sonnet 5)
+  ├── agents/        Risk · CareGap · SDOH · ActionPlanner (OpenAI gpt-5.5 — GD13 revised)
   │                    → structured output, citations validated vs bundle
   ├── orchestrator/  parallel dispatch + SSE stream of findings
   ├── cds-hooks/     patient-view service (public sandbox demoable)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,12 +1,42 @@
 # Active Plan — CareSync AI
 
-**Feature:** `caresync-ai` · **Current slice:** S1 — Walking Skeleton
-**Full plan:** `docs/plans/caresync-ai/implementation-plan.md` (Iteration 1, ponytail-simplified)
+**Feature:** `caresync-ai` · **Current slice:** S2 — Single-agent analysis with citation enforcement
+**Full plan:** `docs/plans/caresync-ai/implementation-plan.md` (Iteration 2)
 **Spec:** `docs/plans/caresync-ai/prd.md` · **Slice def:** `docs/plans/caresync-ai/issues.md`
+
+---
+
+## S2 — Single-agent analysis with citation enforcement (GD11, GD13)
+
+> **Approved: yes (2026-07-04)** — ponytail pass applied. Implementing via `subagent-driven-development` on `feature/caresync-s2-single-agent-analysis`.
+
+### Phase A — Agent foundation & contracts (backend, test-first)
+- [ ] A1. Add `@anthropic-ai/sdk` + `ANTHROPIC_API_KEY` (.env.example); module-level `new Anthropic()` + `MODEL='claude-sonnet-5'` (GD13) — no factory module
+- [ ] A2. Citation validator — **Seam 2**, pure module (TDD): in-bundle citation passes, fabricated dropped/flagged (GD11)
+- [ ] A3. `FhirReadService.getPatientBundle()` → `{resources, validIds}` via one audited `Patient/$everything`; `validIds` derived from resources (test vs HAPI)
+
+### Phase B — Risk agent service + SSE (backend, test-first)
+- [ ] B1. `runRiskAgent(bundle)` (plain fn — no interface until S3): Claude Sonnet 5 structured output `{riskScore, riskLevel, flags[{text,fhirResourceId}], readmissionProbability}`; parse tested with a mocked client
+- [ ] B2. `POST /api/patients/:id/analysis` SSE route (`runAgent` defaulted param, stubbable): stream findings, **validate every fhirResourceId against the bundle before emit**, audit the read; wire into index.ts
+  - *Boundary test (S2 acceptance):* stub agent → 1 in-bundle + 1 fabricated citation → only the valid one returned; all returned citations resolve in the bundle
+
+### Phase C — Frontend: Run Analysis + streaming Risk feed
+- [ ] C1. `streamAnalysis()` in api/client.ts via `fetch` ReadableStream (auth header), parse SSE events
+- [ ] C2. PatientDetail: **Run Analysis** button + one Risk feed box (mockup `#runLabel`/`.feed`), streamed text + validated citation chips
+  - *Deviations recorded:* other 3 feed boxes idle placeholders (S3); agent-graph canvas omitted (S4)
+
+### Phase D — Verification (Seam 2 + E2E)
+- [ ] D1. `npm run test:api` + `npm run test:web` green
+- [ ] D2. Playwright E2E (`frontend-e2e-verification`): Coordinator → Maria → Run Analysis → feed streams → validated finding + citation renders
+- [ ] D3. Live-call evidence vs real Claude Sonnet 5 (structured output + real streaming; fabricated citation dropped end-to-end) — recorded, labeled *live*
+
+**Rollback (S2):** additive, no DB migration; unset `ANTHROPIC_API_KEY` disables analysis (explicit error, not a fake result). Full reset as S1.
+
+---
 
 ## Approved: yes (2026-07-04)
 
-## S1 — Walking Skeleton (stories 17, 33, 34, 36)
+## S1 — Walking Skeleton (stories 17, 33, 34, 36) — ✅ complete
 
 ### Phase A — Scaffold & infra
 - [x] A1. Monorepo scaffold: apps/web (Vite+React+TS+Tailwind), apps/api (Express+TS); Vitest + Jest/Supertest

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10,27 +10,38 @@
 
 > **Approved: yes (2026-07-04)** — ponytail pass applied. Implementing via `subagent-driven-development` on `feature/caresync-s2-single-agent-analysis`.
 
+> **GD13 revised 2026-07-04:** no Anthropic key available for D3 → agent provider switched to **OpenAI `gpt-5.5`** (Responses API), straight substitution under the same `runRiskAgent`/`AgentEvent` contract. Recorded in `plan.md` GD13 and Iteration 2 of `implementation-plan.md`. User-approved.
+
 ### Phase A — Agent foundation & contracts (backend, test-first)
-- [ ] A1. Add `@anthropic-ai/sdk` + `ANTHROPIC_API_KEY` (.env.example); module-level `new Anthropic()` + `MODEL='claude-sonnet-5'` (GD13) — no factory module
-- [ ] A2. Citation validator — **Seam 2**, pure module (TDD): in-bundle citation passes, fabricated dropped/flagged (GD11)
-- [ ] A3. `FhirReadService.getPatientBundle()` → `{resources, validIds}` via one audited `Patient/$everything`; `validIds` derived from resources (test vs HAPI)
+- [x] A1 (revised). Swap `@anthropic-ai/sdk` → `openai`; `OPENAI_API_KEY` (.env.example); `MODEL='gpt-5.5'` (GD13 revised) — no factory module; client built lazily on first use, not at module load (see E3 below)
+- [x] A2. Citation validator — **Seam 2**, pure module (TDD): in-bundle citation passes, fabricated dropped/flagged (GD11)
+- [x] A3. `FhirReadService.getPatientBundle()` → `{resources, validIds}` via one audited `Patient/$everything`; `validIds` derived from resources (test vs HAPI)
 
 ### Phase B — Risk agent service + SSE (backend, test-first)
-- [ ] B1. `runRiskAgent(bundle)` (plain fn — no interface until S3): Claude Sonnet 5 structured output `{riskScore, riskLevel, flags[{text,fhirResourceId}], readmissionProbability}`; parse tested with a mocked client
-- [ ] B2. `POST /api/patients/:id/analysis` SSE route (`runAgent` defaulted param, stubbable): stream findings, **validate every fhirResourceId against the bundle before emit**, audit the read; wire into index.ts
+- [x] B1 (revised). `runRiskAgent(bundle)` (plain fn — no interface until S3): **OpenAI `gpt-5.5`** structured output `{riskScore, riskLevel, flags[{text,fhirResourceId}], readmissionProbability}`; parse tested with a mocked OpenAI client. Same event contract — B2/C1/C2 untouched.
+- [x] B2. `POST /api/patients/:id/analysis` SSE route (`runAgent` defaulted param, stubbable): stream findings, **validate every fhirResourceId against the bundle before emit**, audit the read; wired into index.ts
   - *Boundary test (S2 acceptance):* stub agent → 1 in-bundle + 1 fabricated citation → only the valid one returned; all returned citations resolve in the bundle
 
 ### Phase C — Frontend: Run Analysis + streaming Risk feed
-- [ ] C1. `streamAnalysis()` in api/client.ts via `fetch` ReadableStream (auth header), parse SSE events
-- [ ] C2. PatientDetail: **Run Analysis** button + one Risk feed box (mockup `#runLabel`/`.feed`), streamed text + validated citation chips
+- [x] C1. `streamAnalysis()` in api/client.ts via `fetch` ReadableStream (auth header), parse SSE events
+- [x] C2. PatientDetail: **Run Analysis** button + one Risk feed box (mockup `#runLabel`/`.feed`), streamed text + validated citation chips
   - *Deviations recorded:* other 3 feed boxes idle placeholders (S3); agent-graph canvas omitted (S4)
 
 ### Phase D — Verification (Seam 2 + E2E)
-- [ ] D1. `npm run test:api` + `npm run test:web` green
-- [ ] D2. Playwright E2E (`frontend-e2e-verification`): Coordinator → Maria → Run Analysis → feed streams → validated finding + citation renders
-- [ ] D3. Live-call evidence vs real Claude Sonnet 5 (structured output + real streaming; fabricated citation dropped end-to-end) — recorded, labeled *live*
+- [x] D1. `npm run test:api` (49/49) + `npm run test:web` (14/14) green
+- [x] D2. Playwright E2E (`frontend-e2e-verification`): Coordinator → Maria → Run Analysis → feed streams → validated finding + citation renders. `apps/web/e2e/patient-analysis.spec.ts`. Evidence: packaged UI/local-mock for the stream path (route-intercepted), live-local-stack for login/nav.
+- [x] D3 (revised). **Live** call vs real OpenAI `gpt-5.5`: real SSE run against Maria — ~70 streamed tokens, 9 findings, all 9 `fhirResourceId`s independently verified against a fresh `$everything` fetch (all valid, `droppedCount:0`); fabrication-drop then proven by running the *real* `validateCitations` against those 9 live flags + 1 synthetic fabricated one → 9 valid / 1 dropped. Full detail in `implementation-plan.md` Iteration 2, D3.
 
-**Rollback (S2):** additive, no DB migration; unset `ANTHROPIC_API_KEY` disables analysis (explicit error, not a fake result). Full reset as S1.
+### Post-review fixes (2026-07-04) — `verification-before-completion` + `code-review`
+- [x] E1. SSE route had no error handling around the agent loop (client hang + possible process crash on agent failure) — try/catch + `error` SSE event.
+- [x] E2. Narration `token` stream bypassed GD11 citation validation — `redactUnvalidatedCitations` + `createNarrationBuffer` (Seam 2, `citationValidator.ts`), wired into `analysis.ts`.
+- [x] E3. `new OpenAI()` at module import time crashed the whole API at boot with no key — made lazy; `jest.setup.ts` placeholder-key workaround deleted (no longer needed).
+- [x] E4. Duplicated `PatientBundle`/`AgentFlag` types (Standards) — each now exported once and imported, not redeclared.
+- Full detail + evidence: `implementation-plan.md` Iteration 2 "Post-review fixes", `docs/plans/caresync-ai/verification.md` §7, `docs/plans/caresync-ai/review.md` "Post-review update". `npm run test:api`: 61/61 (was 49/49).
+
+**S2 status: all phases complete (A–D), post-review fixes E1–E4 complete.** `verification-before-completion` and `code-review` both passed. Ready for `finishing-a-development-branch`.
+
+**Rollback (S2):** additive, no DB migration; unset `OPENAI_API_KEY` disables analysis (explicit error, not a fake result — true as of E3; wasn't before it). Full reset as S1.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the Risk agent (OpenAI `gpt-5.5`, GD13-revised from Claude Sonnet 5) with a `POST /api/patients/:id/analysis` SSE route, streaming clinical narration and structured findings to the client.
- Adds citation enforcement (GD11, Seam 2): every `fhirResourceId` — in structured flags *and* in the free-text narration stream — is validated against the patient's retrieved bundle before it reaches the UI; fabricated citations are dropped/redacted.
- Adds the frontend "Run Analysis" control and a streaming Risk feed box on `PatientDetail`, with FHIR citation chips on validated findings.
- Includes fixes from this session's `verification-before-completion` + `code-review` pass, run before merge: the SSE route now degrades gracefully instead of hanging/crashing on an agent failure; narration citations are now enforced (previously only structured flags were checked); the OpenAI client is now built lazily so a missing key can't crash the process at boot; `PatientBundle`/`AgentFlag` types are deduplicated to single sources.

## Test plan
- [x] `FHIR_BASE_URL=http://localhost:8080/fhir npm run test:api` — 15 suites / 61 tests passing
- [x] `npm run test:web` — 5 files / 14 tests passing
- [x] `npm run test:e2e` — 3 Playwright specs passing (login/panel, analysis streaming, social-worker denial)
- [x] `npm run build` / `npm run lint` — both apps clean (pre-existing warn-level warnings only)
- [x] Live-model evidence against real OpenAI `gpt-5.5` + HAPI (D3): ~70 streamed tokens, 9 findings, all 9 `fhirResourceId`s independently verified against a fresh bundle fetch; fabrication-drop proven by running the production `validateCitations` against the real flags plus one synthetic fabricated one

Full detail in `docs/plans/caresync-ai/implementation-plan.md` (Iteration 2), `verification.md`, `review.md`, and the changelog under `docs/superpowers/specs/feature-caresync-s2-single-agent-analysis/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)