### PR TITLE
feat(S8): AI Governance & audit dashboard (W06)

### DIFF
--- a/apps/api/src/db/analysisCache.ts
+++ b/apps/api/src/db/analysisCache.ts
@@ -30,6 +30,29 @@ export function writeAnalysisCache(db: Database.Database, entry: AnalysisCacheEn
   });
 }
 
+/**
+ * S8 A2 — reads every cached analysis row (not just one patient), backing
+ * the W06 governance dashboard's model-performance view. Same row mapping as
+ * readAnalysisCache; no ordering guarantee is needed by any current caller
+ * (governance/service.ts aggregates across all rows rather than displaying
+ * them in a particular order).
+ */
+export function readAllAnalysisCache(db: Database.Database): AnalysisCacheRow[] {
+  const rows = db.prepare('SELECT * FROM analysis_cache').all() as {
+    patient_id: string;
+    result_json: string;
+    model_version: string;
+    created_ts: string;
+  }[];
+
+  return rows.map((row) => ({
+    patientId: row.patient_id,
+    resultJson: JSON.parse(row.result_json),
+    modelVersion: row.model_version,
+    createdTs: row.created_ts,
+  }));
+}
+
 export function readAnalysisCache(db: Database.Database, patientId: string): AnalysisCacheRow | null {
   const row = db.prepare('SELECT * FROM analysis_cache WHERE patient_id = ?').get(patientId) as
     | { patient_id: string; result_json: string; model_version: string; created_ts: string }

--- a/apps/api/src/db/audit.ts
+++ b/apps/api/src/db/audit.ts
@@ -14,3 +14,50 @@ export function writeAudit(db: Database.Database, entry: AuditEntry): void {
     `INSERT INTO audit_log (ts, actor, action, fhir_resource, outcome) VALUES (?, ?, ?, ?, ?)`
   ).run(new Date().toISOString(), entry.actor, entry.action, entry.fhirResource, entry.outcome);
 }
+
+export interface AuditTrailEntry {
+  ts: string;
+  actor: string;
+  action: string;
+  resource: string;
+  outcome: AuditOutcome;
+}
+
+export interface AuditTrailPage {
+  entries: AuditTrailEntry[];
+  total: number;
+}
+
+interface AuditLogRow {
+  ts: string;
+  actor: string;
+  action: string;
+  fhir_resource: string;
+  outcome: AuditOutcome;
+}
+
+/**
+ * S8 A1 — paged, most-recent-first read of the S1 `audit_log` table, backing
+ * the W06 governance dashboard's live audit trail. Ordered by `id DESC`
+ * (insertion order) rather than `ts DESC`: two rows can share the same
+ * millisecond-resolution ISO timestamp under a fast burst of writes (e.g. a
+ * guard-then-read pair), and `id` is the one column guaranteed to break that
+ * tie in actual write order. `total` is the full unpaged row count, so a
+ * caller can render "page X of Y" without a second round trip.
+ */
+export function readAuditTrail(db: Database.Database, limit: number, offset: number): AuditTrailPage {
+  const total = (db.prepare('SELECT COUNT(*) as n FROM audit_log').get() as { n: number }).n;
+  const rows = db
+    .prepare('SELECT ts, actor, action, fhir_resource, outcome FROM audit_log ORDER BY id DESC LIMIT ? OFFSET ?')
+    .all(limit, offset) as AuditLogRow[];
+
+  const entries: AuditTrailEntry[] = rows.map((row) => ({
+    ts: row.ts,
+    actor: row.actor,
+    action: row.action,
+    resource: row.fhir_resource,
+    outcome: row.outcome,
+  }));
+
+  return { entries, total };
+}

--- a/apps/api/src/fhir/client.ts
+++ b/apps/api/src/fhir/client.ts
@@ -277,6 +277,34 @@ export interface AccessTokenProvider {
   getAccessToken(): Promise<string>;
 }
 
+// S8 A3 — real Synthea demographics for GD12 demographic-parity computation
+// (governance/service.ts). `birthDate`/`sex` come straight off `Patient`;
+// `race`/`ethnicity` come off the US Core race/ethnicity extensions
+// scripts/import-fhir.ts writes onto every seeded Patient (see
+// raceEthnicityExtensions there for the exact shape this mirrors). Any of the
+// four is undefined if the source Patient lacks it — age-banding/stratifying
+// an undefined field is governance/service.ts's job, not this read's.
+export interface PatientDemographics {
+  patientId: string;
+  birthDate?: string;
+  sex?: string;
+  race?: string;
+  ethnicity?: string;
+}
+
+const US_CORE_RACE_EXTENSION_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race';
+const US_CORE_ETHNICITY_EXTENSION_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity';
+
+// Reads the `ombCategory` sub-extension's `valueCoding.display` off a
+// top-level US Core race/ethnicity extension — the exact nesting
+// scripts/import-fhir.ts's raceEthnicityExtensions writes (a top-level
+// extension carrying `ombCategory` + `text` sub-extensions).
+function extractOmbCategoryDisplay(patient: any, extensionUrl: string): string | undefined {
+  const extension = (patient.extension ?? []).find((e: any) => e.url === extensionUrl);
+  const ombCategory = (extension?.extension ?? []).find((e: any) => e.url === 'ombCategory');
+  return ombCategory?.valueCoding?.display;
+}
+
 export class FhirReadService {
   constructor(
     private readonly db: Database.Database,
@@ -551,6 +579,37 @@ export class FhirReadService {
         return { patientId, riskScore, hoursSinceEncounter };
       })
       .filter((p): p is PopulationRiskProfile => p !== undefined);
+  }
+
+  /**
+   * S8 A3 — batch demographics read backing GD12 demographic-parity
+   * computation (governance/service.ts's getParityMetrics). Follows
+   * `getPopulationRiskProfile`'s bulk-read pattern just above, but scoped to
+   * exactly the given `patientIds` (a `_id=id1,id2,...` search) rather than
+   * the whole cohort — the caller only ever needs demographics for patients
+   * that have a cached analysis to join against, so fetching the full
+   * ~500-patient population here would be pure waste. Empty `patientIds`
+   * short-circuits to `[]` with no HAPI call and no audit row (there is
+   * nothing to read). Audited once for the whole batch, mirroring
+   * `getPopulationRiskProfile`/`getAssignedPanel`'s audit-once-per-aggregate-
+   * read shape rather than once per patient.
+   */
+  async getPatientDemographics(actor: AuthTokenPayload, patientIds: string[]): Promise<PatientDemographics[]> {
+    if (patientIds.length === 0) return [];
+
+    const resource = 'Population/demographics';
+    this.guard(actor, 'demographic', resource);
+
+    const entries = await this.fetchPages<any>(`/Patient?_id=${patientIds.join(',')}&_count=${patientIds.length}`);
+    writeAudit(this.db, { actor: actor.id, action: 'read', fhirResource: resource, outcome: 'success' });
+
+    return entries.map((e) => ({
+      patientId: e.resource.id,
+      birthDate: e.resource.birthDate,
+      sex: e.resource.gender,
+      race: extractOmbCategoryDisplay(e.resource, US_CORE_RACE_EXTENSION_URL),
+      ethnicity: extractOmbCategoryDisplay(e.resource, US_CORE_ETHNICITY_EXTENSION_URL),
+    }));
   }
 
   /**

--- a/apps/api/src/governance/service.test.ts
+++ b/apps/api/src/governance/service.test.ts
@@ -1,0 +1,98 @@
+import { bucketFor, extractConfidences, ageFromBirthDate, stratify } from './service';
+
+// Direct unit tests for governance/service.ts's pure helpers — boundary
+// cases that are awkward to pin precisely through the HTTP-level fixtures in
+// routes/governance.test.ts (which already cover the happy-path shape).
+// Same convention population/service.ts uses for projectedCostAvoidance.
+
+describe('bucketFor', () => {
+  it('places a value exactly on the 0.5 boundary in the 0.5-0.7 bucket, not 0-0.5', () => {
+    expect(bucketFor(0.5)).toBe('0.5-0.7');
+  });
+
+  it('places a value exactly on the 0.7 boundary in the 0.7-0.85 bucket, not 0.5-0.7', () => {
+    expect(bucketFor(0.7)).toBe('0.7-0.85');
+  });
+
+  it('places a value exactly on the 0.85 boundary in the 0.85-1.0 bucket, not 0.7-0.85', () => {
+    expect(bucketFor(0.85)).toBe('0.85-1.0');
+  });
+
+  it('includes the top bucket upper bound (1.0), unlike the other buckets\' exclusive upper bound', () => {
+    expect(bucketFor(1.0)).toBe('0.85-1.0');
+  });
+
+  it('places 0 in the lowest bucket', () => {
+    expect(bucketFor(0)).toBe('0-0.5');
+  });
+});
+
+describe('extractConfidences', () => {
+  it('collects confidence values across risk/careGap/sdoh finding arrays', () => {
+    const resultJson = {
+      risk: { findings: [{ confidence: 0.9 }, { confidence: 0.4 }] },
+      careGap: { findings: [{ confidence: 0.6 }] },
+      sdoh: { findings: [{ confidence: 0.8 }] },
+    };
+    expect(extractConfidences(resultJson)).toEqual([0.9, 0.4, 0.6, 0.8]);
+  });
+
+  it('skips findings with no confidence field, rather than treating it as 0', () => {
+    const resultJson = { risk: { findings: [{ text: 'no confidence field' }, { confidence: 0.5 }] } };
+    expect(extractConfidences(resultJson)).toEqual([0.5]);
+  });
+
+  it('returns an empty array for null/undefined/malformed input', () => {
+    expect(extractConfidences(null)).toEqual([]);
+    expect(extractConfidences(undefined)).toEqual([]);
+    expect(extractConfidences({})).toEqual([]);
+    expect(extractConfidences({ risk: { findings: 'not-an-array' } })).toEqual([]);
+  });
+});
+
+describe('ageFromBirthDate', () => {
+  it("returns age unchanged when today is exactly this year's birthday", () => {
+    expect(ageFromBirthDate('2000-06-15', new Date('2026-06-15'))).toBe(26);
+  });
+
+  it("has not yet incremented the day before this year's birthday", () => {
+    expect(ageFromBirthDate('2000-06-15', new Date('2026-06-14'))).toBe(25);
+  });
+
+  it("has incremented the day after this year's birthday", () => {
+    expect(ageFromBirthDate('2000-06-15', new Date('2026-06-16'))).toBe(26);
+  });
+
+  it('returns undefined for a missing or unparseable birthDate', () => {
+    expect(ageFromBirthDate(undefined, new Date('2026-06-15'))).toBeUndefined();
+    expect(ageFromBirthDate('not-a-date', new Date('2026-06-15'))).toBeUndefined();
+  });
+});
+
+describe('stratify', () => {
+  it('averages riskScore per group and rounds to one decimal place', () => {
+    const result = stratify([
+      { group: 'A', riskScore: 90 },
+      { group: 'A', riskScore: 81 },
+      { group: 'B', riskScore: 50 },
+    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { group: 'A', patientCount: 2, avgRiskScore: 85.5 },
+        { group: 'B', patientCount: 1, avgRiskScore: 50 },
+      ])
+    );
+  });
+
+  it('skips rows with an undefined group rather than joining an "undefined" bucket', () => {
+    const result = stratify([
+      { group: 'A', riskScore: 90 },
+      { group: undefined, riskScore: 10 },
+    ]);
+    expect(result).toEqual([{ group: 'A', patientCount: 1, avgRiskScore: 90 }]);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(stratify([])).toEqual([]);
+  });
+});

--- a/apps/api/src/governance/service.ts
+++ b/apps/api/src/governance/service.ts
@@ -112,7 +112,11 @@ const CONFIDENCE_BUCKETS: { range: string; min: number; max: number }[] = [
   { range: '0.85-1.0', min: 0.85, max: 1.0 },
 ];
 
-function bucketFor(confidence: number): string | undefined {
+// Exported for direct unit testing (boundary cases — a confidence value
+// landing exactly on 0.5/0.7/0.85 — are awkward to pin precisely through the
+// HTTP-level fixtures in routes/governance.test.ts). Same convention
+// population/service.ts uses for projectedCostAvoidance.
+export function bucketFor(confidence: number): string | undefined {
   for (const bucket of CONFIDENCE_BUCKETS) {
     const isTopBucket = bucket.max === 1.0;
     if (confidence >= bucket.min && (isTopBucket ? confidence <= bucket.max : confidence < bucket.max)) {
@@ -124,7 +128,8 @@ function bucketFor(confidence: number): string | undefined {
 
 // Runtime-only shape (see this section's deviation note above) — deliberately
 // not `AgentFlag[]` etc., since the field being read isn't declared there.
-function extractConfidences(resultJson: unknown): number[] {
+// Exported for direct unit testing.
+export function extractConfidences(resultJson: unknown): number[] {
   const result = resultJson as
     | { risk?: { findings?: { confidence?: unknown }[] }; careGap?: { findings?: { confidence?: unknown }[] }; sdoh?: { findings?: { confidence?: unknown }[] } }
     | null
@@ -198,7 +203,11 @@ const AGE_BANDS: { label: string; min: number; max: number }[] = [
   { label: '65+', min: 65, max: Infinity },
 ];
 
-function ageFromBirthDate(birthDate: string | undefined, now: Date): number | undefined {
+// Exported for direct unit testing (the "hasn't had this year's birthday
+// yet" boundary — `now` landing exactly on, one day before, and one day
+// after the birthday's month/day — is awkward to pin through a live-HAPI
+// fixture, since `now` there is real wall-clock time).
+export function ageFromBirthDate(birthDate: string | undefined, now: Date): number | undefined {
   if (!birthDate) return undefined;
   const dob = new Date(birthDate);
   if (Number.isNaN(dob.getTime())) return undefined;
@@ -220,7 +229,9 @@ function ageBandFor(age: number | undefined): string | undefined {
 // silently join an "undefined" bucket) and averages riskScore per group.
 // Rounded to one decimal place — enough precision to see a real disparity,
 // not so much that it implies false precision over a handful of patients.
-function stratify(rows: { group: string | undefined; riskScore: number }[]): ParityGroupStat[] {
+// Exported for direct unit testing (the "skip an undefined group rather than
+// join an 'undefined' bucket" rule, in particular).
+export function stratify(rows: { group: string | undefined; riskScore: number }[]): ParityGroupStat[] {
   const scoresByGroup = new Map<string, number[]>();
   for (const row of rows) {
     if (row.group === undefined) continue;

--- a/apps/api/src/governance/service.ts
+++ b/apps/api/src/governance/service.ts
@@ -1,0 +1,278 @@
+import Database from 'better-sqlite3';
+import { AuthTokenPayload } from '../auth/jwt';
+import { writeAudit, readAuditTrail, AuditTrailEntry } from '../db/audit';
+import { readAllAnalysisCache } from '../db/analysisCache';
+import { DirectorOnlyError, FhirReadService, PatientDemographics } from '../fhir/client';
+
+// Re-exported so routes/governance.ts doesn't need a second import path for
+// the same Director-only error population/service.ts's router also maps to
+// a 403 — one error type, not two parallel ones (same convention
+// population/service.ts itself follows for fhir/client.ts's DirectorOnlyError).
+export { DirectorOnlyError };
+
+/**
+ * Director-only gate, mirroring population/service.ts's own `assertDirector`
+ * exactly (role check, denial audit, throw DirectorOnlyError). NOT imported
+ * from population/service.ts: that function is private to that module (only
+ * `DirectorOnlyError` itself is exported from there), so this is a deliberate,
+ * minimal duplicate of the same rule rather than a divergence from it — see
+ * fhir/client.ts's DirectorOnlyError doc for why this is the one shared
+ * "role above domain" error type across both modules.
+ */
+function assertDirector(actor: AuthTokenPayload, db: Database.Database, resource: string): void {
+  if (actor.role !== 'director') {
+    writeAudit(db, { actor: actor.id, action: 'read', fhirResource: resource, outcome: 'denied' });
+    throw new DirectorOnlyError(actor.role, 'access governance aggregates');
+  }
+  // No success audit here, same reasoning as population/service.ts's
+  // assertDirector: getAuditTrail below reads the audit_log table itself
+  // (not a FHIR resource), so there is no underlying FHIR read to audit —
+  // recording "Director viewed the audit trail" as its own audit-worthy FHIR
+  // access would conflate the two. getParityMetrics' HAPI demographics read
+  // audits itself via FhirReadService.getPatientDemographics, exactly like
+  // every other FhirReadService method.
+}
+
+const DEFAULT_AUDIT_LIMIT = 50;
+
+export interface AuditTrailResult {
+  entries: AuditTrailEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * S8 A1 — Director-only, paged read of the S1 `audit_log` table (existing
+ * storage only — see readAuditTrail's doc for the most-recent-first
+ * ordering rule).
+ */
+export function getAuditTrail(
+  actor: AuthTokenPayload,
+  db: Database.Database,
+  limit: number = DEFAULT_AUDIT_LIMIT,
+  offset = 0
+): AuditTrailResult {
+  assertDirector(actor, db, 'Governance/audit');
+  const { entries, total } = readAuditTrail(db, limit, offset);
+  return { entries, total, limit, offset };
+}
+
+// --- A2: model performance + confidence distribution --------------------
+
+export interface AnalysisVersionEntry {
+  patientId: string;
+  modelVersion: string;
+  createdTs: string;
+}
+
+export interface ConfidenceBucket {
+  range: string;
+  count: number;
+}
+
+export interface ModelPerformanceResult {
+  analyses: AnalysisVersionEntry[];
+  confidenceDistribution: ConfidenceBucket[];
+}
+
+/**
+ * Deviation note (S8 A2): `AgentFlag` (agents/citationValidator.ts) and the
+ * anonymous careGap/sdoh finding shapes in `AnalysisResultJson`
+ * (routes/analysis.ts) carry no `confidence` field today — none of the three
+ * agent tool schemas (riskAgent.ts/careGapAgent.ts/sdohAgent.ts) ask the
+ * model to report one. The plan's acceptance criteria nonetheless call for a
+ * "confidence distribution derived from actual outputs," and the S1 ponytail
+ * rule for this slice forbids fabricating numbers. Resolution: `analysis_cache.
+ * result_json` is stored (and read back) as loosely-typed JSON, not
+ * constrained by AgentFlag's TS shape at the DB layer (see
+ * db/analysisCache.test.ts, which already round-trips shapes AgentFlag
+ * doesn't describe) — so this reads an *optional* `confidence: number` off
+ * each finding at runtime. Today's live-produced cache rows contribute zero
+ * data to every bucket (an honest reflection of what the agents currently
+ * report, not a missing feature masked as zero); the moment an agent starts
+ * emitting per-finding confidence, this endpoint picks it up with no
+ * migration. This was treated as an engineering resolution of a type/runtime
+ * mismatch, not a guess at an undocumented domain rule.
+ */
+
+// Clinically-meaningful confidence bands (S8 A2): <0.5 is treated as
+// unreliable and unfit to act on without human review; 0.5-0.7 is low-
+// moderate (usable with caution); 0.7-0.85 is moderate-high (generally
+// actionable); 0.85-1.0 is high confidence. This also lines up with the W06
+// mockup's "below 60% confidence — auto-flagged" framing at the low end,
+// while giving finer resolution at the high end where most real findings are
+// expected to land.
+const CONFIDENCE_BUCKETS: { range: string; min: number; max: number }[] = [
+  { range: '0-0.5', min: 0, max: 0.5 },
+  { range: '0.5-0.7', min: 0.5, max: 0.7 },
+  { range: '0.7-0.85', min: 0.7, max: 0.85 },
+  { range: '0.85-1.0', min: 0.85, max: 1.0 },
+];
+
+function bucketFor(confidence: number): string | undefined {
+  for (const bucket of CONFIDENCE_BUCKETS) {
+    const isTopBucket = bucket.max === 1.0;
+    if (confidence >= bucket.min && (isTopBucket ? confidence <= bucket.max : confidence < bucket.max)) {
+      return bucket.range;
+    }
+  }
+  return undefined;
+}
+
+// Runtime-only shape (see this section's deviation note above) — deliberately
+// not `AgentFlag[]` etc., since the field being read isn't declared there.
+function extractConfidences(resultJson: unknown): number[] {
+  const result = resultJson as
+    | { risk?: { findings?: { confidence?: unknown }[] }; careGap?: { findings?: { confidence?: unknown }[] }; sdoh?: { findings?: { confidence?: unknown }[] } }
+    | null
+    | undefined;
+
+  const findingArrays = [result?.risk?.findings, result?.careGap?.findings, result?.sdoh?.findings];
+  const confidences: number[] = [];
+  for (const findings of findingArrays) {
+    if (!Array.isArray(findings)) continue;
+    for (const finding of findings) {
+      if (finding && typeof finding.confidence === 'number') confidences.push(finding.confidence);
+    }
+  }
+  return confidences;
+}
+
+/**
+ * S8 A2 — Director-only model version/timestamp per cached analysis, plus a
+ * confidence distribution bucketed from whatever per-finding `confidence`
+ * values are actually present in the cached agent outputs (see the deviation
+ * note above for why that's "whatever is present," not a guaranteed field).
+ */
+export function getModelPerformance(actor: AuthTokenPayload, db: Database.Database): ModelPerformanceResult {
+  assertDirector(actor, db, 'Governance/model');
+
+  const rows = readAllAnalysisCache(db);
+  const analyses: AnalysisVersionEntry[] = rows.map((row) => ({
+    patientId: row.patientId,
+    modelVersion: row.modelVersion,
+    createdTs: row.createdTs,
+  }));
+
+  const counts = new Map<string, number>(CONFIDENCE_BUCKETS.map((b) => [b.range, 0]));
+  for (const row of rows) {
+    for (const confidence of extractConfidences(row.resultJson)) {
+      const bucket = bucketFor(confidence);
+      if (bucket) counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+    }
+  }
+  const confidenceDistribution: ConfidenceBucket[] = CONFIDENCE_BUCKETS.map((b) => ({
+    range: b.range,
+    count: counts.get(b.range) ?? 0,
+  }));
+
+  return { analyses, confidenceDistribution };
+}
+
+// --- A3: demographic parity (GD12 — computed from real Synthea demographics) ---
+
+export interface ParityGroupStat {
+  group: string;
+  patientCount: number;
+  avgRiskScore: number;
+}
+
+export interface ParityResult {
+  byAgeBand: ParityGroupStat[];
+  bySex: ParityGroupStat[];
+  byRace: ParityGroupStat[];
+  byEthnicity: ParityGroupStat[];
+}
+
+// Common clinical/demographic age bands (S8 A3) — the same <18/18-34/35-49/
+// 50-64/65+ split the plan text itself suggests, coarse enough that even
+// this POC's small cached-analysis cohort populates more than one band.
+const AGE_BANDS: { label: string; min: number; max: number }[] = [
+  { label: '<18', min: -Infinity, max: 17 },
+  { label: '18-34', min: 18, max: 34 },
+  { label: '35-49', min: 35, max: 49 },
+  { label: '50-64', min: 50, max: 64 },
+  { label: '65+', min: 65, max: Infinity },
+];
+
+function ageFromBirthDate(birthDate: string | undefined, now: Date): number | undefined {
+  if (!birthDate) return undefined;
+  const dob = new Date(birthDate);
+  if (Number.isNaN(dob.getTime())) return undefined;
+
+  let age = now.getFullYear() - dob.getFullYear();
+  const hasHadBirthdayThisYear =
+    now.getMonth() > dob.getMonth() || (now.getMonth() === dob.getMonth() && now.getDate() >= dob.getDate());
+  if (!hasHadBirthdayThisYear) age--;
+  return age;
+}
+
+function ageBandFor(age: number | undefined): string | undefined {
+  if (age === undefined) return undefined;
+  return AGE_BANDS.find((band) => age >= band.min && age <= band.max)?.label;
+}
+
+// Groups by `group` (skipping patients whose demographic value for this
+// dimension is unknown — a patient missing a race extension, say, shouldn't
+// silently join an "undefined" bucket) and averages riskScore per group.
+// Rounded to one decimal place — enough precision to see a real disparity,
+// not so much that it implies false precision over a handful of patients.
+function stratify(rows: { group: string | undefined; riskScore: number }[]): ParityGroupStat[] {
+  const scoresByGroup = new Map<string, number[]>();
+  for (const row of rows) {
+    if (row.group === undefined) continue;
+    const scores = scoresByGroup.get(row.group) ?? [];
+    scores.push(row.riskScore);
+    scoresByGroup.set(row.group, scores);
+  }
+
+  return Array.from(scoresByGroup.entries()).map(([group, scores]) => ({
+    group,
+    patientCount: scores.length,
+    avgRiskScore: Math.round((scores.reduce((sum, s) => sum + s, 0) / scores.length) * 10) / 10,
+  }));
+}
+
+/**
+ * S8 A3 — Director-only demographic parity (GD12): joins every cached
+ * analysis's risk score (`resultJson.risk.complete.riskScore`, the same
+ * shape A2 reads) to that patient's REAL HAPI demographics (age computed
+ * from `Patient.birthDate`, sex from `Patient.gender`, race/ethnicity from
+ * the US Core extensions — see `FhirReadService.getPatientDemographics`),
+ * then stratifies risk by each dimension independently. A plain aggregate
+ * over data already in hand — no fairness/ML library, per this slice's
+ * ponytail pass.
+ */
+export async function getParityMetrics(
+  actor: AuthTokenPayload,
+  fhirService: FhirReadService,
+  db: Database.Database
+): Promise<ParityResult> {
+  assertDirector(actor, db, 'Governance/parity');
+
+  const rows = readAllAnalysisCache(db);
+  const riskScoreByPatientId = new Map<string, number>();
+  for (const row of rows) {
+    const riskScore = (row.resultJson as { risk?: { complete?: { riskScore?: unknown } } } | null | undefined)?.risk
+      ?.complete?.riskScore;
+    if (typeof riskScore === 'number') riskScoreByPatientId.set(row.patientId, riskScore);
+  }
+
+  const patientIds = Array.from(riskScoreByPatientId.keys());
+  const demographics = await fhirService.getPatientDemographics(actor, patientIds);
+  const demographicsByPatientId = new Map<string, PatientDemographics>(demographics.map((d) => [d.patientId, d]));
+
+  const now = new Date();
+  const joined = patientIds.map((patientId) => ({
+    riskScore: riskScoreByPatientId.get(patientId)!,
+    demo: demographicsByPatientId.get(patientId),
+  }));
+
+  return {
+    byAgeBand: stratify(joined.map((j) => ({ group: ageBandFor(ageFromBirthDate(j.demo?.birthDate, now)), riskScore: j.riskScore }))),
+    bySex: stratify(joined.map((j) => ({ group: j.demo?.sex, riskScore: j.riskScore }))),
+    byRace: stratify(joined.map((j) => ({ group: j.demo?.race, riskScore: j.riskScore }))),
+    byEthnicity: stratify(joined.map((j) => ({ group: j.demo?.ethnicity, riskScore: j.riskScore }))),
+  };
+}

--- a/apps/api/src/governance/service.ts
+++ b/apps/api/src/governance/service.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import Database from 'better-sqlite3';
 import { AuthTokenPayload } from '../auth/jwt';
 import { writeAudit, readAuditTrail, AuditTrailEntry } from '../db/audit';
@@ -275,4 +277,38 @@ export async function getParityMetrics(
     byRace: stratify(joined.map((j) => ({ group: j.demo?.race, riskScore: j.riskScore }))),
     byEthnicity: stratify(joined.map((j) => ({ group: j.demo?.ethnicity, riskScore: j.riskScore }))),
   };
+}
+
+// --- B — S9 eval headline tile -------------------------------------------
+
+// S8 B — exact path the B2 eval tile reads. S9 (the `npm run eval` harness)
+// doesn't exist yet on this branch; this constant documents the contract it
+// must honor: write its JSON summary to this repo-root path and the tile
+// picks it up with no further wiring. Resolved from `__dirname` (not
+// `process.cwd()`, which varies with the invoking workspace script) — both
+// `src/governance` (tsx/ts-jest) and the built `dist/governance` sit 4
+// directories below the repo root, so the same relative walk-up resolves
+// correctly either way.
+export const EVAL_REPORT_PATH = path.resolve(__dirname, '../../../../docs/eval-report.json');
+
+export interface EvalSummaryResult {
+  available: boolean;
+  summary?: unknown;
+}
+
+/**
+ * S8 B2 — Director-only, stateless read of the S9 evaluation report JSON.
+ * Never throws and never fabricates: a missing file (S9 hasn't shipped yet)
+ * or one that fails to parse both collapse to the same honest
+ * `{ available: false }` the eval tile renders as a graceful empty state.
+ */
+export function getEvalSummary(actor: AuthTokenPayload, db: Database.Database): EvalSummaryResult {
+  assertDirector(actor, db, 'Governance/eval');
+  try {
+    if (!fs.existsSync(EVAL_REPORT_PATH)) return { available: false };
+    const summary = JSON.parse(fs.readFileSync(EVAL_REPORT_PATH, 'utf-8'));
+    return { available: true, summary };
+  } catch {
+    return { available: false };
+  }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { createAuthRouter } from './routes/auth';
 import { createPatientsRouter } from './routes/patients';
 import { createAnalysisRouter } from './routes/analysis';
 import { createPopulationRouter } from './routes/population';
+import { createGovernanceRouter } from './routes/governance';
 import { createTasksRouter } from './routes/tasks';
 import { createEventsRouter, createSubscriptionWebhookRouter } from './routes/events';
 import { createEventHub } from './routes/eventHub';
@@ -59,6 +60,8 @@ if (require.main === module) {
   app.use('/api/patients', createAnalysisRouter(fhirService, orchestrate, db));
   // S5 A2 — Director-only population dashboard aggregates (W02).
   app.use('/api/population', createPopulationRouter(fhirService, db));
+  // S8 A1-A3 — Director-only governance/audit dashboard aggregates (W06).
+  app.use('/api/governance', createGovernanceRouter(fhirService, db));
   // S6 A1 — Director-scoped Task assignment.
   app.use('/api/tasks', createTasksRouter(fhirService));
   // S6 A3 — the client relay (`/api/events`) and HAPI's webhook target

--- a/apps/api/src/routes/governance.test.ts
+++ b/apps/api/src/routes/governance.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import express from 'express';
 import Database from 'better-sqlite3';
 import request from 'supertest';
@@ -10,6 +12,11 @@ import { createGovernanceRouter } from './governance';
 import { FhirReadService } from '../fhir/client';
 
 const FHIR_BASE_URL = process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir';
+
+// Same path governance/service.ts's getEvalSummary reads (repo root
+// docs/eval-report.json) — resolved the same way (4 dirs up from
+// src/routes), so this test can't drift from where the endpoint actually looks.
+const EVAL_REPORT_PATH = path.resolve(__dirname, '../../../../docs/eval-report.json');
 
 function buildApp(db: Database.Database) {
   const app = express();
@@ -289,6 +296,71 @@ describe('GET /api/governance/parity', () => {
 
   it('requires auth', async () => {
     const res = await request(app).get('/api/governance/parity');
+    expect(res.status).toBe(401);
+  });
+});
+
+// S8 B — tiny, stateless read of the S9 evaluation report JSON. S9 doesn't
+// exist yet in this branch, so this endpoint must behave honestly (`available:
+// false`, never throw/fabricate) until it does. Both branches are seeded by
+// directly writing/removing the real file at the exact path the service reads
+// (not a mock fs) — this is a stateless file-existence check, not a DB table,
+// so exercising the real filesystem is the simplest faithful test.
+describe('GET /api/governance/eval', () => {
+  let db: Database.Database;
+  let app: express.Express;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    seedDemoUsers(db);
+    app = buildApp(db);
+    fs.rmSync(EVAL_REPORT_PATH, { force: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(EVAL_REPORT_PATH, { force: true });
+  });
+
+  it('returns { available: false } when no S9 report file exists yet', async () => {
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/eval').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: false });
+  });
+
+  it('returns { available: true, summary } with the parsed JSON when the report file exists', async () => {
+    fs.writeFileSync(EVAL_REPORT_PATH, JSON.stringify({ headline: 'Care Gap sensitivity 91%', generatedAt: '2026-07-05T00:00:00.000Z' }));
+
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/eval').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      available: true,
+      summary: { headline: 'Care Gap sensitivity 91%', generatedAt: '2026-07-05T00:00:00.000Z' },
+    });
+  });
+
+  it('returns { available: false } (not a 500) when the report file exists but is not valid JSON', async () => {
+    fs.writeFileSync(EVAL_REPORT_PATH, '{ not valid json');
+
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/eval').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: false });
+  });
+
+  it('is denied for a Coordinator (Director-only)', async () => {
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+    const res = await request(app).get('/api/governance/eval').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/governance/eval');
     expect(res.status).toBe(401);
   });
 });

--- a/apps/api/src/routes/governance.test.ts
+++ b/apps/api/src/routes/governance.test.ts
@@ -1,0 +1,294 @@
+import express from 'express';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import { migrate } from '../db';
+import { seedDemoUsers, DEMO_PASSWORD } from '../db/seed';
+import { writeAudit } from '../db/audit';
+import { writeAnalysisCache } from '../db/analysisCache';
+import { createAuthRouter } from './auth';
+import { createGovernanceRouter } from './governance';
+import { FhirReadService } from '../fhir/client';
+
+const FHIR_BASE_URL = process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir';
+
+function buildApp(db: Database.Database) {
+  const app = express();
+  app.use(express.json());
+  const fhirService = new FhirReadService(db, FHIR_BASE_URL);
+  app.use('/api/auth', createAuthRouter(db));
+  app.use('/api/governance', createGovernanceRouter(fhirService, db));
+  return app;
+}
+
+async function loginAs(app: express.Express, email: string): Promise<string> {
+  const res = await request(app).post('/api/auth/login').send({ email, password: DEMO_PASSWORD });
+  return res.body.token;
+}
+
+// S8 A1 — Director-only audit trail, paging the existing S1 audit_log table.
+describe('GET /api/governance/audit', () => {
+  let db: Database.Database;
+  let app: express.Express;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    seedDemoUsers(db);
+    app = buildApp(db);
+  });
+
+  it('lists real audit rows most-recent-first with actor + timestamp, paged by limit/offset', async () => {
+    writeAudit(db, { actor: 'coord-1', action: 'read', fhirResource: 'Patient/maria-chen', outcome: 'success' });
+    writeAudit(db, { actor: 'coord-2', action: 'read', fhirResource: 'Patient/john-doe', outcome: 'denied' });
+    writeAudit(db, { actor: 'coord-3', action: 'update', fhirResource: 'Task/abc', outcome: 'success' });
+
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/audit?limit=2&offset=0').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    // Most-recent-first: the last row written (coord-3) comes first.
+    expect(res.body.entries[0]).toMatchObject({
+      actor: 'coord-3',
+      action: 'update',
+      resource: 'Task/abc',
+      outcome: 'success',
+    });
+    expect(res.body.entries[0].ts).toEqual(expect.any(String));
+    expect(res.body.entries[1]).toMatchObject({ actor: 'coord-2', resource: 'Patient/john-doe', outcome: 'denied' });
+    expect(res.body.total).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is denied for a Coordinator (Director-only)', async () => {
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+    const res = await request(app).get('/api/governance/audit').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/governance/audit');
+    expect(res.status).toBe(401);
+  });
+});
+
+// S8 A2 — model version/timestamp per cached analysis, plus a confidence
+// distribution bucketed from the actual cached agent outputs. `resultJson` is
+// stored (and read back) as loosely-typed JSON (see db/analysisCache.ts), so
+// this seeds rows with a `confidence` field per finding even though
+// `AgentFlag` (agents/citationValidator.ts) does not currently declare one —
+// see governance/service.ts's doc for why that's a deliberate, forward-
+// compatible reading rather than a fabrication.
+describe('GET /api/governance/model', () => {
+  let db: Database.Database;
+  let app: express.Express;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    seedDemoUsers(db);
+    app = buildApp(db);
+  });
+
+  it('returns model version + timestamp per analysis and a confidence distribution matching hand-computed buckets', async () => {
+    writeAnalysisCache(db, {
+      patientId: 'patient-a',
+      modelVersion: 'gpt-5.5',
+      createdTs: '2026-07-01T00:00:00.000Z',
+      resultJson: {
+        risk: { findings: [{ text: 'f1', fhirResourceId: 'Condition/1', confidence: 0.92 }, { text: 'f2', fhirResourceId: 'Condition/2', confidence: 0.4 }] },
+        careGap: { findings: [{ gapType: 'g1', fhirResourceId: 'Condition/3', confidence: 0.6 }] },
+        sdoh: { findings: [{ domain: 'housing', fhirResourceId: 'Observation/1', confidence: 0.8 }] },
+      },
+    });
+    writeAnalysisCache(db, {
+      patientId: 'patient-b',
+      modelVersion: 'gpt-5.5',
+      createdTs: '2026-07-02T00:00:00.000Z',
+      resultJson: {
+        risk: { findings: [{ text: 'f3', fhirResourceId: 'Condition/4', confidence: 0.3 }] },
+        careGap: { findings: [] },
+        sdoh: { findings: [{ domain: 'food', fhirResourceId: 'Observation/2', confidence: 0.95 }] },
+      },
+    });
+
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/model').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.analyses).toEqual(
+      expect.arrayContaining([
+        { patientId: 'patient-a', modelVersion: 'gpt-5.5', createdTs: '2026-07-01T00:00:00.000Z' },
+        { patientId: 'patient-b', modelVersion: 'gpt-5.5', createdTs: '2026-07-02T00:00:00.000Z' },
+      ])
+    );
+
+    // Hand-computed: confidences are 0.92, 0.4, 0.6, 0.8 (patient-a) and
+    // 0.3, 0.95 (patient-b) -> 0-0.5: {0.4, 0.3}=2, 0.5-0.7: {0.6}=1,
+    // 0.7-0.85: {0.8}=1, 0.85-1.0: {0.92, 0.95}=2.
+    expect(res.body.confidenceDistribution).toEqual(
+      expect.arrayContaining([
+        { range: '0-0.5', count: 2 },
+        { range: '0.5-0.7', count: 1 },
+        { range: '0.7-0.85', count: 1 },
+        { range: '0.85-1.0', count: 2 },
+      ])
+    );
+  });
+
+  it('is denied for a Coordinator (Director-only)', async () => {
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+    const res = await request(app).get('/api/governance/model').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/governance/model');
+    expect(res.status).toBe(401);
+  });
+});
+
+// S8 A3 — demographic parity computed from REAL Synthea/HAPI demographics
+// (GD12), joined to cached risk scores. Exercised against the real
+// disposable HAPI container (same Seam 1 pattern as fhir/client.test.ts and
+// routes/tasks.test.ts): probe Patients are created with a fixed id (PUT,
+// the same create-with-known-id method scripts/import-fhir.ts uses) carrying
+// the exact US Core race/ethnicity extension shape that script writes, then
+// deleted in afterEach.
+describe('GET /api/governance/parity', () => {
+  let db: Database.Database;
+  let app: express.Express;
+  const createdPatientIds: string[] = [];
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    seedDemoUsers(db);
+    app = buildApp(db);
+  });
+
+  afterEach(async () => {
+    while (createdPatientIds.length > 0) {
+      const id = createdPatientIds.pop()!;
+      await fetch(`${FHIR_BASE_URL}/Patient/${id}`, { method: 'DELETE' }).catch(() => undefined);
+    }
+  });
+
+  function raceEthnicityExtensions(race: { code: string; display: string }, ethnicity: { code: string; display: string }) {
+    return [
+      {
+        url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+        extension: [
+          { url: 'ombCategory', valueCoding: { system: 'urn:oid:2.16.840.1.113883.6.238', code: race.code, display: race.display } },
+          { url: 'text', valueString: race.display },
+        ],
+      },
+      {
+        url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+        extension: [
+          { url: 'ombCategory', valueCoding: { system: 'urn:oid:2.16.840.1.113883.6.238', code: ethnicity.code, display: ethnicity.display } },
+          { url: 'text', valueString: ethnicity.display },
+        ],
+      },
+    ];
+  }
+
+  async function createProbePatient(opts: {
+    id: string;
+    birthDate: string;
+    gender: string;
+    race: { code: string; display: string };
+    ethnicity: { code: string; display: string };
+  }): Promise<void> {
+    await fetch(`${FHIR_BASE_URL}/Patient/${opts.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/fhir+json' },
+      body: JSON.stringify({
+        resourceType: 'Patient',
+        id: opts.id,
+        extension: raceEthnicityExtensions(opts.race, opts.ethnicity),
+        name: [{ given: ['Probe'], family: 'Patient' }],
+        gender: opts.gender,
+        birthDate: opts.birthDate,
+      }),
+    });
+    createdPatientIds.push(opts.id);
+  }
+
+  const BLACK = { code: '2054-5', display: 'Black or African American' };
+  const WHITE = { code: '2106-3', display: 'White' };
+  const NOT_HISPANIC = { code: '2186-5', display: 'Not Hispanic or Latino' };
+  const HISPANIC = { code: '2135-2', display: 'Hispanic or Latino' };
+
+  it('stratifies cached risk scores by age band, sex, race, and ethnicity, reflecting a known-imbalanced fixture', async () => {
+    await createProbePatient({ id: 'gov-a3-patient-1', birthDate: '1950-01-01', gender: 'female', race: BLACK, ethnicity: NOT_HISPANIC });
+    await createProbePatient({ id: 'gov-a3-patient-2', birthDate: '1950-06-15', gender: 'female', race: BLACK, ethnicity: NOT_HISPANIC });
+    await createProbePatient({ id: 'gov-a3-patient-3', birthDate: '1995-03-10', gender: 'male', race: WHITE, ethnicity: HISPANIC });
+
+    writeAnalysisCache(db, {
+      patientId: 'gov-a3-patient-1',
+      modelVersion: 'gpt-5.5',
+      createdTs: '2026-07-01T00:00:00.000Z',
+      resultJson: { risk: { complete: { riskScore: 92 } } },
+    });
+    writeAnalysisCache(db, {
+      patientId: 'gov-a3-patient-2',
+      modelVersion: 'gpt-5.5',
+      createdTs: '2026-07-01T00:00:00.000Z',
+      resultJson: { risk: { complete: { riskScore: 78 } } },
+    });
+    writeAnalysisCache(db, {
+      patientId: 'gov-a3-patient-3',
+      modelVersion: 'gpt-5.5',
+      createdTs: '2026-07-01T00:00:00.000Z',
+      resultJson: { risk: { complete: { riskScore: 15 } } },
+    });
+
+    const token = await loginAs(app, 'director@caresync.demo');
+    const res = await request(app).get('/api/governance/parity').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    expect(res.body.byAgeBand).toEqual(
+      expect.arrayContaining([
+        { group: '65+', patientCount: 2, avgRiskScore: 85 },
+        { group: '18-34', patientCount: 1, avgRiskScore: 15 },
+      ])
+    );
+    expect(res.body.bySex).toEqual(
+      expect.arrayContaining([
+        { group: 'female', patientCount: 2, avgRiskScore: 85 },
+        { group: 'male', patientCount: 1, avgRiskScore: 15 },
+      ])
+    );
+    expect(res.body.byRace).toEqual(
+      expect.arrayContaining([
+        { group: 'Black or African American', patientCount: 2, avgRiskScore: 85 },
+        { group: 'White', patientCount: 1, avgRiskScore: 15 },
+      ])
+    );
+    expect(res.body.byEthnicity).toEqual(
+      expect.arrayContaining([
+        { group: 'Not Hispanic or Latino', patientCount: 2, avgRiskScore: 85 },
+        { group: 'Hispanic or Latino', patientCount: 1, avgRiskScore: 15 },
+      ])
+    );
+
+    // Known-imbalanced fixture -> the expected disparity direction: the
+    // Black/female/65+ group's avg risk score is well above the White/male/
+    // 18-34 group's, not just marginally.
+    const black = res.body.byRace.find((r: any) => r.group === 'Black or African American');
+    const white = res.body.byRace.find((r: any) => r.group === 'White');
+    expect(black.avgRiskScore).toBeGreaterThan(white.avgRiskScore);
+  }, 20000);
+
+  it('is denied for a Coordinator (Director-only)', async () => {
+    const token = await loginAs(app, 'coordinator@caresync.demo');
+    const res = await request(app).get('/api/governance/parity').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/governance/parity');
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import Database from 'better-sqlite3';
 import { requireAuth } from '../middleware/auth';
 import { FhirReadService, ScopeDeniedError } from '../fhir/client';
-import { getAuditTrail, getModelPerformance, getParityMetrics, DirectorOnlyError } from '../governance/service';
+import { getAuditTrail, getModelPerformance, getParityMetrics, getEvalSummary, DirectorOnlyError } from '../governance/service';
 
 const DEFAULT_LIMIT = 50;
 
@@ -48,6 +48,21 @@ export function createGovernanceRouter(fhirService: FhirReadService, db: Databas
   router.get('/parity', async (req, res) => {
     try {
       const result = await getParityMetrics(req.auth!, fhirService, db);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof DirectorOnlyError || err instanceof ScopeDeniedError) {
+        res.status(403).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  // S8 B2 — B2's eval headline tile; see governance/service.ts's
+  // EVAL_REPORT_PATH doc for the exact file this reads.
+  router.get('/eval', (req, res) => {
+    try {
+      const result = getEvalSummary(req.auth!, db);
       res.json(result);
     } catch (err) {
       if (err instanceof DirectorOnlyError || err instanceof ScopeDeniedError) {

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import Database from 'better-sqlite3';
+import { requireAuth } from '../middleware/auth';
+import { FhirReadService, ScopeDeniedError } from '../fhir/client';
+import { getAuditTrail, getModelPerformance, getParityMetrics, DirectorOnlyError } from '../governance/service';
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * S8 A1 — Director-only W06 governance aggregate endpoints (audit trail,
+ * model performance, demographic parity), mirroring routes/population.ts's
+ * shape exactly: a thin HTTP shell over governance/service.ts, mapping
+ * DirectorOnlyError/ScopeDeniedError to 403 the same way population's router
+ * does.
+ */
+export function createGovernanceRouter(fhirService: FhirReadService, db: Database.Database): Router {
+  const router = Router();
+  router.use(requireAuth);
+
+  router.get('/audit', (req, res) => {
+    try {
+      const limit = parseNonNegativeInt(req.query.limit, DEFAULT_LIMIT);
+      const offset = parseNonNegativeInt(req.query.offset, 0);
+      const result = getAuditTrail(req.auth!, db, limit, offset);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof DirectorOnlyError || err instanceof ScopeDeniedError) {
+        res.status(403).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  router.get('/model', (req, res) => {
+    try {
+      const result = getModelPerformance(req.auth!, db);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof DirectorOnlyError || err instanceof ScopeDeniedError) {
+        res.status(403).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  router.get('/parity', async (req, res) => {
+    try {
+      const result = await getParityMetrics(req.auth!, fhirService, db);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof DirectorOnlyError || err instanceof ScopeDeniedError) {
+        res.status(403).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  return router;
+}
+
+// `?limit=`/`?offset=` — this repo has no prior list-endpoint pagination
+// convention (routes/tasks.ts and routes/patients.ts both return unpaged
+// lists), so limit/offset was picked as the plainest SQL-native convention;
+// any non-numeric or negative value falls back to the given default rather
+// than 500ing on a malformed query string.
+function parseNonNegativeInt(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}

--- a/apps/web/e2e/director-governance.spec.ts
+++ b/apps/web/e2e/director-governance.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+// S8 Phase B — Director → W06 Governance dashboard, driven end-to-end against
+// the real API + live HAPI (audit_log, analysis_cache, and HAPI demographics
+// for the parity join). `docs/eval-report.json` does not exist on this branch
+// (S9 hasn't shipped), so the eval tile is expected to render its real,
+// honest empty state — not a mocked one.
+test('Director logs in, navigates to Governance from the nav link, and sees real audit/model/parity data plus the S9 eval placeholder', async ({
+  page,
+}) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('director@caresync.demo');
+  await page.getByLabel('Password').fill('Demo1234!');
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  await expect(page).toHaveURL(/\/population$/);
+
+  // Nav link only a Director sees (S8 B3).
+  await page.getByRole('link', { name: 'Governance' }).click();
+  await expect(page).toHaveURL(/\/governance$/);
+  await expect(page.getByRole('heading', { name: 'AI Governance Center' })).toBeVisible();
+
+  // Zone 2 metric tiles computed from real aggregates — not the mockup's
+  // hardcoded 84.2% / 2,847 / 23 / 0.94.
+  const analysesTile = page.getByTestId('governance-tile-analyses-cached');
+  await expect(analysesTile).toBeVisible({ timeout: 15_000 });
+
+  // Column A — real audit trail rows (ts/actor/action/resource/outcome),
+  // most-recent-first. Every FHIR read/write across the whole demo (logins,
+  // coordinator panel reads, etc.) writes an audit_log row, so this dev DB's
+  // table is never empty by the time this spec runs — assert on the real
+  // outcome vocabulary (success/denied/error) rather than a specific actor,
+  // since which actor most recently wrote a row depends on E2E run order.
+  const auditTrail = page.getByTestId('governance-audit-trail');
+  await expect(auditTrail).toBeVisible();
+  await expect(auditTrail.getByText('No audit events yet.')).not.toBeVisible();
+  await expect(auditTrail.getByText(/success|denied|error/i).first()).toBeVisible({ timeout: 15_000 });
+
+  // Column B — native Canvas confidence chart renders (no chart library).
+  const confidenceChart = page.getByTestId('governance-confidence-chart');
+  await expect(confidenceChart).toBeVisible();
+  await expect(confidenceChart.locator('canvas')).toBeAttached();
+
+  // Column C — native Canvas parity radar renders.
+  const parityChart = page.getByTestId('governance-parity-chart');
+  await expect(parityChart).toBeVisible();
+  await expect(parityChart.locator('canvas')).toBeAttached();
+
+  // Eval tile — S9 doesn't exist on this branch, so this must be the honest
+  // empty state, not a fabricated number.
+  const evalTile = page.getByTestId('governance-eval-tile');
+  await expect(evalTile).toBeVisible();
+  await expect(evalTile.getByText(/not yet available/i)).toBeVisible({ timeout: 15_000 });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { PatientPanel } from './pages/PatientPanel';
 import { PatientDetail } from './pages/PatientDetail';
 import { Population } from './pages/Population';
 import { PopulationPatientList } from './pages/PopulationPatientList';
+import { Governance } from './pages/Governance';
 import { TaskQueue } from './pages/TaskQueue';
 import { TaskDetail } from './pages/TaskDetail';
 import { TaskCenter } from './pages/TaskCenter';
@@ -40,6 +41,14 @@ function App() {
           element={
             <RoleGuard role="director">
               <PopulationPatientList />
+            </RoleGuard>
+          }
+        />
+        <Route
+          path="/governance"
+          element={
+            <RoleGuard role="director">
+              <Governance />
             </RoleGuard>
           }
         />

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -122,6 +122,86 @@ export function getPopulationSummary(): Promise<PopulationSummary> {
   return apiFetch('/api/population/summary');
 }
 
+// --- S8 B — governance dashboard (W06) -----------------------------------
+
+/** One row of the S1 `audit_log`, as returned by `GET /api/governance/audit` — no patient name/recommendation text/FHIR citation/confidence% (the mockup's per-entry fields): the real audit_log row only ever carries these five columns (`apps/api/src/db/audit.ts`'s `AuditTrailEntry`). */
+export interface AuditTrailEntry {
+  ts: string;
+  actor: string;
+  action: string;
+  resource: string;
+  outcome: 'success' | 'denied' | 'error';
+}
+
+export interface AuditTrailResult {
+  entries: AuditTrailEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** Director-only, paged read of the audit trail — mirrors `apps/api/src/routes/governance.ts`'s `?limit=&offset=` query params exactly. */
+export function getAuditTrail(limit = 50, offset = 0): Promise<AuditTrailResult> {
+  return apiFetch(`/api/governance/audit?limit=${limit}&offset=${offset}`);
+}
+
+export interface AnalysisVersionEntry {
+  patientId: string;
+  modelVersion: string;
+  createdTs: string;
+}
+
+/** One of the 4 fixed confidence bands `apps/api/src/governance/service.ts`'s `CONFIDENCE_BUCKETS` derives from actual cached agent output — not the mockup's 5 hardcoded demo bands. */
+export interface ConfidenceBucket {
+  range: string;
+  count: number;
+}
+
+export interface ModelPerformanceResult {
+  analyses: AnalysisVersionEntry[];
+  confidenceDistribution: ConfidenceBucket[];
+}
+
+export function getModelPerformance(): Promise<ModelPerformanceResult> {
+  return apiFetch('/api/governance/model');
+}
+
+/** One demographic group's cached-risk-score stat within a single stratification dimension (age band / sex / race / ethnicity). */
+export interface ParityGroupStat {
+  group: string;
+  patientCount: number;
+  avgRiskScore: number;
+}
+
+export interface ParityResult {
+  byAgeBand: ParityGroupStat[];
+  bySex: ParityGroupStat[];
+  byRace: ParityGroupStat[];
+  byEthnicity: ParityGroupStat[];
+}
+
+/** Director-only demographic parity (GD12) — real, computed from cached risk scores joined to live HAPI demographics; see `apps/api/src/governance/service.ts`'s `getParityMetrics` doc. */
+export function getParityMetrics(): Promise<ParityResult> {
+  return apiFetch('/api/governance/parity');
+}
+
+/**
+ * The B2 eval headline tile's data source: a stateless read of the S9
+ * evaluation report JSON (`docs/eval-report.json`, repo root — see
+ * `apps/api/src/governance/service.ts`'s `EVAL_REPORT_PATH`). S9 doesn't
+ * exist on this branch, so `available` is `false` today and will stay that
+ * way until S9 ships; `summary`'s shape is deliberately `unknown` since S9's
+ * JSON contract isn't defined yet.
+ */
+export interface EvalSummaryResult {
+  available: boolean;
+  summary?: unknown;
+}
+
+export function getEvalSummary(): Promise<EvalSummaryResult> {
+  return apiFetch('/api/governance/eval');
+}
+
 export type AgentId = 'risk' | 'careGap' | 'sdoh' | 'actionPlanner';
 
 /**

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -116,3 +116,40 @@ describe('AppShell — S6 B1 live assignment notification', () => {
     expect(unsubscribe).toHaveBeenCalled();
   });
 });
+
+// S8 B3 — the Director's only way to reach the W06 governance dashboard from
+// anywhere other than their post-login home route (`/population`).
+describe('AppShell — S8 B3 Governance nav link (Director-only)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('shows a Governance link for a Director', () => {
+    localStorage.setItem('caresync_token', tokenFor('director'));
+    const queryClient = new QueryClient();
+
+    renderShell(queryClient);
+
+    expect(screen.getByRole('link', { name: 'Governance' })).toHaveAttribute('href', '/governance');
+  });
+
+  it('does not show a Governance link for a Coordinator or Social Worker', () => {
+    localStorage.setItem('caresync_token', tokenFor('coordinator'));
+    const queryClient = new QueryClient();
+
+    renderShell(queryClient);
+
+    expect(screen.queryByRole('link', { name: 'Governance' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the Tasks/Task Center links for a Director (no PRD story scopes them to that role)', () => {
+    localStorage.setItem('caresync_token', tokenFor('director'));
+    const queryClient = new QueryClient();
+
+    renderShell(queryClient);
+
+    expect(screen.queryByRole('link', { name: 'Tasks' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Task Center' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -104,6 +104,16 @@ export function AppShell() {
                 Task Center
               </Link>
             )}
+            {/* S8 B3 — the Director's only nav affordance to reach W06 from
+                anywhere other than their post-login home (`/population`);
+                Coordinator/Social Worker have no PRD story for this screen,
+                so no link for those roles (mirrors the Tasks/Task Center
+                links above, which are likewise scoped to their own roles). */}
+            {user.role === 'director' && (
+              <Link to="/governance" className="text-label text-text-muted hover:text-text transition-colors">
+                Governance
+              </Link>
+            )}
             <BellIcon className="text-text-muted w-4 h-4" />
             <span
               className="w-7 h-7 rounded-full bg-surface-raised border border-border-light text-cyan text-xs font-bold flex items-center justify-center"

--- a/apps/web/src/components/ConfidenceChart.test.tsx
+++ b/apps/web/src/components/ConfidenceChart.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ConfidenceChart, paintConfidenceFrame } from './ConfidenceChart';
+import type { ConfidenceBucket } from '../api/client';
+
+const BUCKETS: ConfidenceBucket[] = [
+  { range: '0-0.5', count: 2 },
+  { range: '0.5-0.7', count: 1 },
+  { range: '0.7-0.85', count: 1 },
+  { range: '0.85-1.0', count: 4 },
+];
+
+/** Same hand-rolled 2D context stub pattern as `PopulationScatterChart.test.tsx`'s `makeStubCtx`. */
+function makeStubCtx() {
+  return {
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    arcTo: vi.fn(),
+    closePath: vi.fn(),
+    fillText: vi.fn(),
+    setTransform: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    fillStyle: '' as string,
+    strokeStyle: '' as string,
+    lineWidth: 0,
+    font: '' as string,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+}
+
+describe('paintConfidenceFrame — pure-ish draw seam (direct, no React)', () => {
+  it('clears the frame and draws one rounded-top bar per bucket', () => {
+    const ctx = makeStubCtx();
+    paintConfidenceFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, BUCKETS);
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 300, 200);
+    // 4 buckets -> 4 filled bar paths (each uses arcTo for its 2 rounded top corners).
+    expect(ctx.arcTo.mock.calls.length).toBe(8);
+    expect(ctx.fill.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('renders a count label above and a band label below each bar (fillText called at least twice per bucket)', () => {
+    const ctx = makeStubCtx();
+    paintConfidenceFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, BUCKETS);
+    expect(ctx.fillText.mock.calls.length).toBeGreaterThanOrEqual(8);
+    const texts = ctx.fillText.mock.calls.map((call) => call[0]);
+    expect(texts).toContain('2'); // count label for the 0-0.5 bucket
+    expect(texts).toContain('85–100%'); // band label for the 0.85-1.0 bucket
+  });
+
+  it('does not throw for an all-zero distribution (todays honest state)', () => {
+    const ctx = makeStubCtx();
+    const allZero = BUCKETS.map((b) => ({ ...b, count: 0 }));
+    expect(() => paintConfidenceFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, allZero)).not.toThrow();
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 300, 200);
+  });
+
+  it('does not throw and draws nothing bucket-wise for an empty distribution', () => {
+    const ctx = makeStubCtx();
+    expect(() => paintConfidenceFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, [])).not.toThrow();
+    expect(ctx.arcTo).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfidenceChart — mount/unmount guard (no real canvas context in jsdom)', () => {
+  afterEach(() => cleanup());
+
+  it('mounts and unmounts cleanly with no real canvas context', () => {
+    const { unmount, container } = render(<ConfidenceChart buckets={BUCKETS} />);
+    expect(container.querySelector('canvas')).toBeInTheDocument();
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('paints on mount using the buckets prop it was given', () => {
+    const ctx = makeStubCtx();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    render(<ConfidenceChart buckets={BUCKETS} />);
+    expect(ctx.clearRect).toHaveBeenCalled();
+    expect(ctx.arcTo.mock.calls.length).toBe(8);
+    vi.restoreAllMocks();
+  });
+});

--- a/apps/web/src/components/ConfidenceChart.tsx
+++ b/apps/web/src/components/ConfidenceChart.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import type { ConfidenceBucket } from '../api/client';
+import { computeConfidenceBarLayout, formatConfidenceBandLabel, CONFIDENCE_CHART_PADDING } from '../lib/confidenceChartGeometry';
+
+/**
+ * Native Canvas 2D render of the W06 `#confChart` bar chart (S8 B1), ported
+ * from `reference-materials/caresync-governance.html`'s `drawBars()` — see
+ * `confidenceChartGeometry.ts` for the extracted pure math and the 4-real-
+ * bucket departure from the mockup's 5 hardcoded bands. No chart library
+ * (GD10) — plain `CanvasRenderingContext2D` calls, same seam shape as
+ * `PopulationScatterChart.tsx`.
+ *
+ * Deliberately dropped from the mockup: the intro grow-from-zero animation
+ * and the top-bucket glow (`shadowBlur`) — this is a static snapshot render
+ * of whatever the API currently returns, not an animated reveal, matching
+ * `PopulationScatterChart.tsx`'s own "static snapshot, not an animated
+ * intro" convention.
+ */
+export interface ConfidenceChartProps {
+  buckets: ConfidenceBucket[];
+}
+
+const GRID_STROKE = '#1A3450';
+const COUNT_LABEL_COLOR = '#C8E6F5';
+const BAND_LABEL_COLOR = '#5A8FAA';
+
+/**
+ * Paints exactly one frame of the confidence distribution bar chart. Pure
+ * with respect to the DOM (only touches the passed `ctx`) — exercised
+ * directly in tests with a stub 2D context, same pattern as
+ * `PopulationScatterChart.tsx`'s `paintScatterFrame`.
+ */
+export function paintConfidenceFrame(ctx: CanvasRenderingContext2D, W: number, H: number, buckets: ConfidenceBucket[]): void {
+  ctx.clearRect(0, 0, W, H);
+  if (buckets.length === 0) return;
+
+  const { left, right, top, bottom } = CONFIDENCE_CHART_PADDING;
+  const plotTop = top;
+  const plotBottom = H - bottom;
+
+  /* faint grid lines at 0/50/100% of plot height, same as the mockup */
+  ctx.strokeStyle = GRID_STROKE;
+  ctx.lineWidth = 1;
+  [0, 0.5, 1].forEach((f) => {
+    const y = plotTop + (plotBottom - plotTop) * (1 - f) + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(left, y);
+    ctx.lineTo(W - right, y);
+    ctx.stroke();
+  });
+
+  const bars = computeConfidenceBarLayout(buckets, W, H);
+  bars.forEach((bar) => {
+    /* rounded-top bar, same corner-radius construction as the mockup */
+    const r = Math.min(3, bar.height);
+    ctx.fillStyle = bar.color;
+    ctx.beginPath();
+    ctx.moveTo(bar.x, bar.y + bar.height);
+    ctx.lineTo(bar.x, bar.y + r);
+    ctx.arcTo(bar.x, bar.y, bar.x + r, bar.y, r);
+    ctx.lineTo(bar.x + bar.width - r, bar.y);
+    ctx.arcTo(bar.x + bar.width, bar.y, bar.x + bar.width, bar.y + r, r);
+    ctx.lineTo(bar.x + bar.width, bar.y + bar.height);
+    ctx.closePath();
+    ctx.fill();
+
+    /* count label above the bar */
+    ctx.fillStyle = COUNT_LABEL_COLOR;
+    ctx.font = "700 10px 'SF Mono', Menlo, monospace";
+    ctx.textAlign = 'center';
+    ctx.fillText(String(bar.count), bar.x + bar.width / 2, bar.y - 4);
+
+    /* band label below the bar */
+    ctx.fillStyle = BAND_LABEL_COLOR;
+    ctx.font = "9px -apple-system, 'Segoe UI', sans-serif";
+    ctx.fillText(formatConfidenceBandLabel(bar.range), bar.x + bar.width / 2, H - 4);
+  });
+}
+
+export function ConfidenceChart({ buckets }: ConfidenceChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const bucketsRef = useRef(buckets);
+  bucketsRef.current = buckets;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return; // SSR / detached-ref guard.
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return; // jsdom / unsupported-canvas guard.
+
+    function draw() {
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas!.clientWidth;
+      const h = canvas!.clientHeight;
+      canvas!.width = Math.round(w * dpr);
+      canvas!.height = Math.round(h * dpr);
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      paintConfidenceFrame(ctx!, w, h, bucketsRef.current);
+    }
+
+    draw();
+    window.addEventListener('resize', draw);
+    return () => window.removeEventListener('resize', draw);
+    // Static snapshot, not an animation loop — repaint on data/resize only,
+    // same convention as PopulationScatterChart.tsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buckets]);
+
+  return <canvas ref={canvasRef} className="block w-full h-full" />;
+}

--- a/apps/web/src/components/ParityRadarChart.test.tsx
+++ b/apps/web/src/components/ParityRadarChart.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ParityRadarChart, paintParityFrame } from './ParityRadarChart';
+import type { ParityAxis } from '../lib/parityScore';
+
+const AXES: ParityAxis[] = [
+  { label: 'Age Band', value: 0.92 },
+  { label: 'Sex', value: 1.0 },
+  { label: 'Race', value: 0.5 },
+  { label: 'Ethnicity', value: 1.0 },
+];
+
+/** Same hand-rolled 2D context stub pattern as `PopulationScatterChart.test.tsx`'s `makeStubCtx`. */
+function makeStubCtx() {
+  return {
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    fillText: vi.fn(),
+    setTransform: vi.fn(),
+    setLineDash: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    fillStyle: '' as string,
+    strokeStyle: '' as string,
+    lineWidth: 0,
+    font: '' as string,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+  };
+}
+
+describe('paintParityFrame — pure-ish draw seam (direct, no React)', () => {
+  it('clears the frame and draws one vertex dot per axis', () => {
+    const ctx = makeStubCtx();
+    paintParityFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, AXES);
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 300, 200);
+    expect(ctx.arc.mock.calls.length).toBe(AXES.length);
+  });
+
+  it('draws a label and a formatted value for each axis', () => {
+    const ctx = makeStubCtx();
+    paintParityFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, AXES);
+    const texts = ctx.fillText.mock.calls.map((call) => call[0]);
+    expect(texts).toContain('Age Band');
+    expect(texts).toContain('0.50');
+    expect(texts).toContain('1.00');
+  });
+
+  it('draws the dashed threshold ring', () => {
+    const ctx = makeStubCtx();
+    paintParityFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, AXES);
+    expect(ctx.setLineDash).toHaveBeenCalledWith([4, 4]);
+  });
+
+  it('does not throw for an empty axis list', () => {
+    const ctx = makeStubCtx();
+    expect(() => paintParityFrame(ctx as unknown as CanvasRenderingContext2D, 300, 200, [])).not.toThrow();
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+});
+
+describe('ParityRadarChart — mount/unmount guard (no real canvas context in jsdom)', () => {
+  afterEach(() => cleanup());
+
+  it('mounts and unmounts cleanly with no real canvas context', () => {
+    const { unmount, container } = render(<ParityRadarChart axes={AXES} />);
+    expect(container.querySelector('canvas')).toBeInTheDocument();
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('paints on mount using the axes prop it was given', () => {
+    const ctx = makeStubCtx();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    render(<ParityRadarChart axes={AXES} />);
+    expect(ctx.clearRect).toHaveBeenCalled();
+    expect(ctx.arc.mock.calls.length).toBe(AXES.length);
+    vi.restoreAllMocks();
+  });
+});

--- a/apps/web/src/components/ParityRadarChart.tsx
+++ b/apps/web/src/components/ParityRadarChart.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef } from 'react';
+import type { ParityAxis } from '../lib/parityScore';
+import { radiusForValue, axisColor, axisPoint, RADAR_RINGS, RADAR_THRESHOLD, RADAR_MARGIN } from '../lib/parityRadarGeometry';
+
+/**
+ * Native Canvas 2D render of the W06 `#radarChart` demographic equity radar
+ * (S8 B1), ported from
+ * `reference-materials/caresync-governance.html`'s `drawRadar()` — see
+ * `parityRadarGeometry.ts`/`parityScore.ts` for the extracted pure math and
+ * the 4-real-axis departure from the mockup's 6 hardcoded axes. No chart
+ * library (GD10) — plain `CanvasRenderingContext2D` calls, same seam shape
+ * as `PopulationScatterChart.tsx`.
+ *
+ * Deliberately dropped from the mockup: the polygon-grow-from-center intro
+ * animation — this is a static snapshot render (the polygon always draws at
+ * its final radius), matching `PopulationScatterChart.tsx`'s and
+ * `ConfidenceChart.tsx`'s "static snapshot, not an animated intro"
+ * convention for this task.
+ */
+export interface ParityRadarChartProps {
+  axes: ParityAxis[];
+}
+
+const BORDER = '#1A3450';
+const BORDER_LIGHT = '#244A6A';
+const MUTED = '#5A8FAA';
+const EMERALD = '#0FC48A';
+const COLOR_HEX: Record<string, string> = { emerald: EMERALD, amber: '#F0970A', red: '#E84848' };
+
+/**
+ * Paints exactly one frame of the demographic equity radar. Pure with
+ * respect to the DOM (only touches the passed `ctx`) — exercised directly in
+ * tests with a stub 2D context, same pattern as
+ * `PopulationScatterChart.tsx`'s `paintScatterFrame`.
+ */
+export function paintParityFrame(ctx: CanvasRenderingContext2D, W: number, H: number, axes: ParityAxis[]): void {
+  ctx.clearRect(0, 0, W, H);
+  const n = axes.length;
+  if (n === 0) return;
+
+  const cx = W / 2;
+  const cy = H / 2 + 2;
+  const R = Math.min(W, H) / 2 - RADAR_MARGIN;
+
+  function ring(r: number) {
+    ctx.beginPath();
+    for (let i = 0; i <= n; i++) {
+      const p = axisPoint(i % n, n, r, cx, cy);
+      if (i === 0) ctx.moveTo(p.x, p.y);
+      else ctx.lineTo(p.x, p.y);
+    }
+  }
+
+  /* grid rings */
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = 1;
+  RADAR_RINGS.forEach((v) => {
+    ring(radiusForValue(v, R));
+    ctx.stroke();
+  });
+
+  /* spokes */
+  for (let i = 0; i < n; i++) {
+    const p = axisPoint(i, n, R, cx, cy);
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(p.x, p.y);
+    ctx.strokeStyle = BORDER;
+    ctx.stroke();
+  }
+
+  /* dashed threshold ring */
+  ctx.save();
+  ctx.setLineDash([4, 4]);
+  ctx.strokeStyle = 'rgba(240,151,10,.55)';
+  ctx.lineWidth = 1;
+  ring(radiusForValue(RADAR_THRESHOLD, R));
+  ctx.stroke();
+  ctx.restore();
+
+  /* ideal-parity outer ring (1.0) */
+  ctx.strokeStyle = BORDER_LIGHT;
+  ctx.lineWidth = 1.4;
+  ring(R);
+  ctx.stroke();
+
+  /* actual polygon */
+  ctx.beginPath();
+  for (let j = 0; j <= n; j++) {
+    const k = j % n;
+    const p = axisPoint(k, n, radiusForValue(axes[k].value, R), cx, cy);
+    if (j === 0) ctx.moveTo(p.x, p.y);
+    else ctx.lineTo(p.x, p.y);
+  }
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(15,196,138,.13)';
+  ctx.fill();
+  ctx.strokeStyle = EMERALD;
+  ctx.lineWidth = 1.6;
+  ctx.stroke();
+
+  /* vertex dots + labels */
+  ctx.font = "9px -apple-system, 'Segoe UI', sans-serif";
+  axes.forEach((axis, i) => {
+    const color = COLOR_HEX[axisColor(axis.value)];
+    const vp = axisPoint(i, n, radiusForValue(axis.value, R), cx, cy);
+    ctx.beginPath();
+    ctx.arc(vp.x, vp.y, 3, 0, Math.PI * 2);
+    ctx.fillStyle = color;
+    ctx.fill();
+
+    const lp = axisPoint(i, n, R + 13, cx, cy);
+    ctx.textAlign = Math.abs(lp.x - cx) < 6 ? 'center' : lp.x > cx ? 'left' : 'right';
+    ctx.fillStyle = MUTED;
+    ctx.fillText(axis.label, lp.x, lp.y - 1);
+    ctx.fillStyle = color;
+    ctx.font = "700 9px 'SF Mono', Menlo, monospace";
+    ctx.fillText(axis.value.toFixed(2), lp.x, lp.y + 10);
+    ctx.font = "9px -apple-system, 'Segoe UI', sans-serif";
+  });
+}
+
+export function ParityRadarChart({ axes }: ParityRadarChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const axesRef = useRef(axes);
+  axesRef.current = axes;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return; // SSR / detached-ref guard.
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return; // jsdom / unsupported-canvas guard.
+
+    function draw() {
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas!.clientWidth;
+      const h = canvas!.clientHeight;
+      canvas!.width = Math.round(w * dpr);
+      canvas!.height = Math.round(h * dpr);
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      paintParityFrame(ctx!, w, h, axesRef.current);
+    }
+
+    draw();
+    window.addEventListener('resize', draw);
+    return () => window.removeEventListener('resize', draw);
+    // Static snapshot, not an animation loop — repaint on data/resize only,
+    // same convention as PopulationScatterChart.tsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [axes]);
+
+  return <canvas ref={canvasRef} className="block w-full h-full" />;
+}

--- a/apps/web/src/lib/confidenceChartGeometry.test.ts
+++ b/apps/web/src/lib/confidenceChartGeometry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeConfidenceBarLayout,
+  confidenceBucketColor,
+  formatConfidenceBandLabel,
+  averageConfidence,
+  CONFIDENCE_CHART_PADDING,
+} from './confidenceChartGeometry';
+
+describe('computeConfidenceBarLayout — pure bucket-count -> pixel-bar projection', () => {
+  const buckets = [
+    { range: '0-0.5', count: 2 },
+    { range: '0.5-0.7', count: 1 },
+    { range: '0.7-0.85', count: 1 },
+    { range: '0.85-1.0', count: 4 },
+  ];
+
+  it('scales the tallest bar to the full plot height and others proportionally', () => {
+    const layout = computeConfidenceBarLayout(buckets, 300, 200);
+    expect(layout).toHaveLength(4);
+    const tallest = layout.find((b) => b.range === '0.85-1.0')!;
+    const plotTop = CONFIDENCE_CHART_PADDING.top;
+    const plotBottom = 200 - CONFIDENCE_CHART_PADDING.bottom;
+    expect(tallest.y).toBeCloseTo(plotTop);
+    expect(tallest.height).toBeCloseTo(plotBottom - plotTop);
+
+    const shortest = layout.find((b) => b.range === '0.5-0.7')!;
+    expect(shortest.height).toBeCloseTo((1 / 4) * (plotBottom - plotTop));
+  });
+
+  it('lays bars out left-to-right in the given bucket order with equal widths', () => {
+    const layout = computeConfidenceBarLayout(buckets, 300, 200);
+    expect(layout[0].x).toBeLessThan(layout[1].x);
+    expect(layout[1].x).toBeLessThan(layout[2].x);
+    expect(layout[2].x).toBeLessThan(layout[3].x);
+    expect(layout[0].width).toBeCloseTo(layout[1].width);
+  });
+
+  it('does not divide by zero when every bucket count is zero (todays honest all-zero state)', () => {
+    const allZero = buckets.map((b) => ({ ...b, count: 0 }));
+    const layout = computeConfidenceBarLayout(allZero, 300, 200);
+    expect(layout).toHaveLength(4);
+    layout.forEach((bar) => {
+      expect(bar.height).toBe(0);
+      expect(Number.isFinite(bar.y)).toBe(true);
+    });
+  });
+
+  it('returns an empty layout for an empty bucket list, without throwing', () => {
+    expect(() => computeConfidenceBarLayout([], 300, 200)).not.toThrow();
+    expect(computeConfidenceBarLayout([], 300, 200)).toEqual([]);
+  });
+});
+
+describe('confidenceBucketColor — clinical-meaning color mapping (matches governance/service.ts bands)', () => {
+  it('maps each real bucket range to a distinct token color', () => {
+    expect(confidenceBucketColor('0-0.5')).toBe('#E84848');
+    expect(confidenceBucketColor('0.5-0.7')).toBe('#F0970A');
+    expect(confidenceBucketColor('0.7-0.85')).toBe('#00C8FF');
+    expect(confidenceBucketColor('0.85-1.0')).toBe('#0FC48A');
+  });
+
+  it('falls back to a default color for an unrecognized range rather than throwing', () => {
+    expect(() => confidenceBucketColor('unexpected')).not.toThrow();
+  });
+});
+
+describe('formatConfidenceBandLabel — human-readable band label below each bar', () => {
+  it('formats a fractional range as a percent range', () => {
+    expect(formatConfidenceBandLabel('0-0.5')).toBe('0–50%');
+    expect(formatConfidenceBandLabel('0.85-1.0')).toBe('85–100%');
+  });
+});
+
+describe('averageConfidence — bucket-midpoint approximation over real distribution counts', () => {
+  it('returns undefined when every bucket is empty (no confidence values reported yet)', () => {
+    const allZero = [
+      { range: '0-0.5', count: 0 },
+      { range: '0.5-0.7', count: 0 },
+      { range: '0.7-0.85', count: 0 },
+      { range: '0.85-1.0', count: 0 },
+    ];
+    expect(averageConfidence(allZero)).toBeUndefined();
+  });
+
+  it('computes a count-weighted average of bucket midpoints', () => {
+    // All 4 in the top bucket (midpoint .925) -> average is exactly .925.
+    const allTop = [
+      { range: '0-0.5', count: 0 },
+      { range: '0.5-0.7', count: 0 },
+      { range: '0.7-0.85', count: 0 },
+      { range: '0.85-1.0', count: 4 },
+    ];
+    expect(averageConfidence(allTop)).toBeCloseTo(0.925);
+  });
+});

--- a/apps/web/src/lib/confidenceChartGeometry.ts
+++ b/apps/web/src/lib/confidenceChartGeometry.ts
@@ -1,0 +1,139 @@
+import type { ConfidenceBucket } from '../api/client';
+
+/**
+ * Pure geometry/color math for the W06 `#confChart` bar chart (S8 B1),
+ * extracted from `reference-materials/caresync-governance.html`'s
+ * `drawBars()` so it's unit-testable without a real `CanvasRenderingContext2D`
+ * (jsdom has none) — same split as `populationScatterGeometry.ts` for
+ * `PopulationScatterChart`.
+ *
+ * Deliberate departure from the mockup: the mockup hardcodes 5 demo bands
+ * (50-59% ... 90-100%) with fabricated counts. The real
+ * `GET /api/governance/model` endpoint (`governance/service.ts`) only ever
+ * returns the 4 fixed buckets it derives from actual cached agent output
+ * (`0-0.5`, `0.5-0.7`, `0.7-0.85`, `0.85-1.0`), so this chart is driven by
+ * exactly those 4 real buckets — not the mockup's 5. No intro animation
+ * either (unlike the mockup's `ease()`/`requestAnimationFrame` ramp): this is
+ * a static snapshot render, same convention `PopulationScatterChart.tsx`
+ * documents for its own departure from the mockup's animated scatter.
+ */
+
+export interface ChartPadding {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/** Padding for the bar chart's plot area — leaves room for the count label above and band label below each bar (ported from the mockup's `padL/padR/padT/padB`, `top`/`bottom` widened slightly since the real render has no legend to borrow vertical space from). */
+export const CONFIDENCE_CHART_PADDING: ChartPadding = { left: 8, right: 8, top: 20, bottom: 18 };
+
+/** Horizontal gap between bars, unchanged from the mockup's `gap`. */
+const GAP_PX = 10;
+
+export interface ConfidenceBucketInput {
+  range: string;
+  count: number;
+}
+
+export interface ConfidenceBarLayout {
+  range: string;
+  count: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+}
+
+// Colors keyed to the exact 4 bucket ranges `governance/service.ts`'s
+// CONFIDENCE_BUCKETS emits, following that module's own clinical-meaning doc
+// comment: <0.5 unreliable (red), 0.5-0.7 low-moderate (amber), 0.7-0.85
+// moderate-high (cyan), 0.85-1.0 high confidence (emerald) — a 4-color ramp
+// rather than the mockup's mostly-cyan 5-band scheme, since our buckets carry
+// a real pass/fail-adjacent meaning the mockup's demo bands didn't need to.
+const BUCKET_COLOR: Record<string, string> = {
+  '0-0.5': '#E84848',
+  '0.5-0.7': '#F0970A',
+  '0.7-0.85': '#00C8FF',
+  '0.85-1.0': '#0FC48A',
+};
+const DEFAULT_BAR_COLOR = '#00C8FF';
+
+export function confidenceBucketColor(range: string): string {
+  return BUCKET_COLOR[range] ?? DEFAULT_BAR_COLOR;
+}
+
+/**
+ * Projects confidence buckets to pixel bar rectangles inside a `width` x
+ * `height` chart area. Scales against the tallest bucket's count (falling
+ * back to 1 when every bucket is 0, e.g. today's honest all-zero
+ * distribution — see `governance/service.ts`'s deviation note) so bars never
+ * divide by zero and simply render at height 0 rather than NaN.
+ */
+export function computeConfidenceBarLayout(
+  buckets: ConfidenceBucketInput[],
+  width: number,
+  height: number,
+  padding: ChartPadding = CONFIDENCE_CHART_PADDING
+): ConfidenceBarLayout[] {
+  const n = buckets.length;
+  if (n === 0) return [];
+
+  const plotW = width - padding.left - padding.right;
+  const plotH = height - padding.top - padding.bottom;
+  const barWidth = (plotW - GAP_PX * (n - 1)) / n;
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+
+  return buckets.map((bucket, i) => {
+    const barHeight = (bucket.count / max) * plotH;
+    return {
+      range: bucket.range,
+      count: bucket.count,
+      x: padding.left + i * (barWidth + GAP_PX),
+      y: padding.top + plotH - barHeight,
+      width: barWidth,
+      height: barHeight,
+      color: confidenceBucketColor(bucket.range),
+    };
+  });
+}
+
+/** Formats a `"min-max"` fractional bucket range (e.g. `"0.85-1.0"`) as a percent range (`"85–100%"`) for the label drawn below each bar. */
+export function formatConfidenceBandLabel(range: string): string {
+  const [minStr, maxStr] = range.split('-');
+  const min = Math.round(Number(minStr) * 100);
+  const max = Math.round(Number(maxStr) * 100);
+  return `${min}–${max}%`;
+}
+
+// Bucket midpoints used only to approximate a single "average confidence"
+// headline tile from the bucketed distribution the API returns — the API
+// deliberately does not return raw per-finding confidence values (see
+// `governance/service.ts`'s `extractConfidences`, which reads them but only
+// ever surfaces the bucketed counts), so an exact average isn't available.
+// This is a documented approximation over real counts (same "derived stat,
+// not fabricated" category as `population/service.ts`'s
+// `projectedCostAvoidance`), not a guess.
+const BUCKET_MIDPOINT: Record<string, number> = {
+  '0-0.5': 0.25,
+  '0.5-0.7': 0.6,
+  '0.7-0.85': 0.775,
+  '0.85-1.0': 0.925,
+};
+
+/**
+ * Count-weighted average of bucket midpoints, or `undefined` when every
+ * bucket is empty (no confidence values have been reported by any agent yet
+ * — today's honest state) so the caller can render "—" instead of a
+ * misleading 0%/NaN.
+ */
+export function averageConfidence(buckets: ConfidenceBucketInput[]): number | undefined {
+  const total = buckets.reduce((sum, b) => sum + b.count, 0);
+  if (total === 0) return undefined;
+  const weighted = buckets.reduce((sum, b) => sum + b.count * (BUCKET_MIDPOINT[b.range] ?? 0), 0);
+  return weighted / total;
+}
+
+// Re-exported for callers that want the API's own bucket type name.
+export type { ConfidenceBucket };

--- a/apps/web/src/lib/parityRadarGeometry.test.ts
+++ b/apps/web/src/lib/parityRadarGeometry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { radiusForValue, axisColor, axisPoint, RADAR_VMIN, RADAR_RINGS, RADAR_THRESHOLD } from './parityRadarGeometry';
+
+describe('radiusForValue — radial scale floor (ported from the mockup so small gaps read)', () => {
+  it('exposes the same VMIN floor as the mockup (0.75)', () => {
+    expect(RADAR_VMIN).toBe(0.75);
+  });
+
+  it('maps the floor value to radius 0', () => {
+    expect(radiusForValue(RADAR_VMIN, 100)).toBe(0);
+  });
+
+  it('maps 1.0 (perfect parity) to the full radius', () => {
+    expect(radiusForValue(1, 100)).toBeCloseTo(100);
+  });
+
+  it('clamps below the floor to radius 0 rather than a negative radius', () => {
+    expect(radiusForValue(0, 100)).toBe(0);
+  });
+});
+
+describe('axisColor — same emerald/amber/red thresholds as the mockup', () => {
+  it('is emerald at/above 0.90', () => {
+    expect(axisColor(0.9)).toBe('emerald');
+    expect(axisColor(1)).toBe('emerald');
+  });
+
+  it('is amber between 0.885 and 0.90', () => {
+    expect(axisColor(0.885)).toBe('amber');
+    expect(axisColor(0.89)).toBe('amber');
+  });
+
+  it('is red below 0.885', () => {
+    expect(axisColor(0.5)).toBe('red');
+    expect(axisColor(0)).toBe('red');
+  });
+});
+
+describe('axisPoint — evenly-spaced axis positions around a center, starting at 12 oclock', () => {
+  it('places the first axis straight up from center', () => {
+    const p = axisPoint(0, 4, 100, 50, 50);
+    expect(p.x).toBeCloseTo(50);
+    expect(p.y).toBeCloseTo(-50);
+  });
+
+  it('places 4 axes 90 degrees apart', () => {
+    const top = axisPoint(0, 4, 100, 0, 0);
+    const right = axisPoint(1, 4, 100, 0, 0);
+    expect(top.x).toBeCloseTo(0);
+    expect(right.x).toBeCloseTo(100);
+    expect(right.y).toBeCloseTo(0);
+  });
+});
+
+describe('RADAR_RINGS / RADAR_THRESHOLD — visual structure ported from the mockup', () => {
+  it('keeps the mockups grid ring values and 0.90 dashed threshold', () => {
+    expect(RADAR_RINGS).toEqual([0.8, 0.85, 0.95]);
+    expect(RADAR_THRESHOLD).toBe(0.9);
+  });
+});

--- a/apps/web/src/lib/parityRadarGeometry.ts
+++ b/apps/web/src/lib/parityRadarGeometry.ts
@@ -1,0 +1,59 @@
+import type { ParityAxis } from './parityScore';
+
+/**
+ * Pure geometry/color math for the W06 `#radarChart` demographic equity
+ * radar (S8 B1), extracted from
+ * `reference-materials/caresync-governance.html`'s `drawRadar()` so it's
+ * unit-testable without a real `CanvasRenderingContext2D` (jsdom has none) —
+ * same split as `populationScatterGeometry.ts` for `PopulationScatterChart`.
+ * The ring/spoke/threshold-line visual structure is kept from the mockup
+ * unchanged; only the axis set and axis values are real (see
+ * `parityScore.ts`'s `buildParityAxes` doc for which 4 axes and why the
+ * mockup's other 2 were dropped rather than fabricated).
+ */
+
+export interface RadarPoint {
+  x: number;
+  y: number;
+}
+
+/** Radial scale floor, unchanged from the mockup's `VMIN` — values below this floor plot at the center, so small real gaps near 1.0 are still visually legible instead of being crushed into a tiny sliver near the edge. */
+export const RADAR_VMIN = 0.75;
+
+/** Grid ring values, unchanged from the mockup. */
+export const RADAR_RINGS = [0.8, 0.85, 0.95];
+
+/** Dashed amber threshold ring, unchanged from the mockup's "target >= 0.90" framing. */
+export const RADAR_THRESHOLD = 0.9;
+
+/** Outer chart margin (px), unchanged from the mockup's `R = min(W,H)/2 - 26`. */
+export const RADAR_MARGIN = 26;
+
+/** `rOf()` from the mockup, unchanged: maps a 0-1 value to a pixel radius against the `RADAR_VMIN` floor, clamped so a value at or below the floor never plots at a negative radius. */
+export function radiusForValue(value: number, R: number): number {
+  return R * Math.max(0, (value - RADAR_VMIN) / (1 - RADAR_VMIN));
+}
+
+export type AxisColorName = 'emerald' | 'amber' | 'red';
+
+/** `axisColor()` from the mockup, unchanged thresholds: >=0.90 emerald, >=0.885 amber, else red. */
+export function axisColor(value: number): AxisColorName {
+  if (value >= 0.9) return 'emerald';
+  if (value >= 0.885) return 'amber';
+  return 'red';
+}
+
+/**
+ * `pt()` from the mockup, generalized to take the center as a parameter
+ * instead of reading it from a closure, so it's pure and directly testable.
+ * Axis 0 sits at 12 o'clock; axes proceed clockwise, evenly spaced around
+ * `n` total axes.
+ */
+export function axisPoint(index: number, n: number, r: number, cx: number, cy: number): RadarPoint {
+  const angle = -Math.PI / 2 + (index * 2 * Math.PI) / n;
+  return { x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) };
+}
+
+// Re-exported so callers importing radar geometry don't need a second import
+// path for the axis shape it consumes.
+export type { ParityAxis };

--- a/apps/web/src/lib/parityScore.test.ts
+++ b/apps/web/src/lib/parityScore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { computeDimensionParity, buildParityAxes } from './parityScore';
+import type { ParityGroupStat, ParityResult } from '../api/client';
+
+const group = (group: string, avgRiskScore: number): ParityGroupStat => ({ group, patientCount: 1, avgRiskScore });
+
+describe('computeDimensionParity — derived 0-1 parity value over real avgRiskScore spread', () => {
+  it('is 1.0 (perfect parity) when there are 0 populated groups', () => {
+    expect(computeDimensionParity([])).toBe(1);
+  });
+
+  it('is 1.0 (nothing to compare) when there is exactly 1 populated group', () => {
+    expect(computeDimensionParity([group('65+', 87)])).toBe(1);
+  });
+
+  it('is 1.0 when every group has the identical avgRiskScore', () => {
+    expect(computeDimensionParity([group('a', 50), group('b', 50), group('c', 50)])).toBe(1);
+  });
+
+  it('is 1.0 (not NaN) when every group has an avgRiskScore of 0', () => {
+    expect(computeDimensionParity([group('a', 0), group('b', 0)])).toBe(1);
+  });
+
+  it('computes 1 - (max-min)/max for a real spread', () => {
+    // max=100, min=50 -> 1 - 50/100 = 0.5
+    expect(computeDimensionParity([group('a', 100), group('b', 50)])).toBeCloseTo(0.5);
+  });
+
+  it('clamps to [0,1] and never goes negative or above 1', () => {
+    const result = computeDimensionParity([group('a', 100), group('b', 0)]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('buildParityAxes — 4 real axes (age band/sex/race/ethnicity), no fabricated payer/geography/language', () => {
+  const PARITY: ParityResult = {
+    byAgeBand: [group('65+', 90), group('18-34', 30)],
+    bySex: [group('female', 60), group('male', 60)],
+    byRace: [group('Black or African American', 92), group('White', 20)],
+    byEthnicity: [group('Not Hispanic or Latino', 55)],
+  };
+
+  it('produces exactly 4 axes labeled Age Band / Sex / Race / Ethnicity', () => {
+    const axes = buildParityAxes(PARITY);
+    expect(axes.map((a) => a.label)).toEqual(['Age Band', 'Sex', 'Race', 'Ethnicity']);
+  });
+
+  it('derives each axis value from computeDimensionParity over that dimension\'s real groups', () => {
+    const axes = buildParityAxes(PARITY);
+    const byLabel = Object.fromEntries(axes.map((a) => [a.label, a.value]));
+    expect(byLabel['Sex']).toBe(1); // identical avgRiskScore
+    expect(byLabel['Ethnicity']).toBe(1); // single populated group
+    expect(byLabel['Age Band']).toBeCloseTo(computeDimensionParity(PARITY.byAgeBand));
+    expect(byLabel['Race']).toBeCloseTo(computeDimensionParity(PARITY.byRace));
+  });
+});

--- a/apps/web/src/lib/parityScore.ts
+++ b/apps/web/src/lib/parityScore.ts
@@ -1,0 +1,61 @@
+import type { ParityGroupStat, ParityResult } from '../api/client';
+
+/**
+ * S8 B — derived per-dimension "parity" value in [0,1] for one demographic
+ * stratification (e.g. `byRace`). This is a computed statistic over data
+ * already in hand (`ParityGroupStat[]`, real HAPI-demographics-joined risk
+ * scores from `GET /api/governance/parity`) — NOT a fabricated number, same
+ * category as `apps/api/src/population/service.ts`'s `projectedCostAvoidance`
+ * doc comment.
+ *
+ * Formula: `1 - (max(avgRiskScore) - min(avgRiskScore)) / max(avgRiskScore)`
+ * — the relative spread between the highest- and lowest-average-risk group
+ * in this dimension, subtracted from perfect parity (1.0). A dimension where
+ * every group's average risk score is identical scores 1.0; one where the
+ * highest group's average risk is double the lowest's scores 0.5. Clamped to
+ * [0,1] as a defensive bound, not because today's inputs can exceed it.
+ *
+ * A dimension with 0 or 1 populated groups has nothing to compare — treated
+ * as perfect parity (1.0), not NaN/undefined. The same 1.0 fallback applies
+ * when every populated group's avgRiskScore is 0 (max === 0): there is no
+ * risk signal to be unequal about, so this is an honest "nothing to see"
+ * result rather than a divide-by-zero NaN.
+ */
+export function computeDimensionParity(groups: Pick<ParityGroupStat, 'avgRiskScore'>[]): number {
+  if (groups.length <= 1) return 1;
+
+  const scores = groups.map((g) => g.avgRiskScore);
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  if (max === 0) return 1;
+
+  const raw = 1 - (max - min) / max;
+  return Math.min(1, Math.max(0, raw));
+}
+
+export interface ParityAxis {
+  label: string;
+  value: number;
+}
+
+/**
+ * The 4 real axes for the W06 demographic equity radar (S8 B1) — age band,
+ * sex, race, ethnicity, each backed by `GET /api/governance/parity`'s real
+ * stratified groups. Deliberately does NOT include the mockup's "Payer
+ * Type," "Geography," or "Language" axes: no backing data for any of those
+ * three exists anywhere in this system (no payer, geography, or
+ * language-preference field is captured by S1-S8), so fabricating a score
+ * for them would be exactly the dishonest-chrome problem this slice's
+ * `CLAUDE.md` rule and `html-mockup-fidelity` skill both call out. Race and
+ * Ethnicity are kept as two separate axes (not the mockup's single combined
+ * "Race/Ethnicity") since the API returns two independent real
+ * stratifications for them.
+ */
+export function buildParityAxes(parity: ParityResult): ParityAxis[] {
+  return [
+    { label: 'Age Band', value: computeDimensionParity(parity.byAgeBand) },
+    { label: 'Sex', value: computeDimensionParity(parity.bySex) },
+    { label: 'Race', value: computeDimensionParity(parity.byRace) },
+    { label: 'Ethnicity', value: computeDimensionParity(parity.byEthnicity) },
+  ];
+}

--- a/apps/web/src/pages/Governance.test.tsx
+++ b/apps/web/src/pages/Governance.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Governance } from './Governance';
+import * as client from '../api/client';
+import type { AuditTrailResult, ModelPerformanceResult, ParityResult, EvalSummaryResult } from '../api/client';
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    getAuditTrail: vi.fn(),
+    getModelPerformance: vi.fn(),
+    getParityMetrics: vi.fn(),
+    getEvalSummary: vi.fn(),
+  };
+});
+
+const MOCK_AUDIT: AuditTrailResult = {
+  entries: [
+    { ts: '2026-07-06T09:42:18.000Z', actor: 'coord-1', action: 'read', resource: 'Patient/maria-chen', outcome: 'success' },
+    { ts: '2026-07-06T09:31:05.000Z', actor: 'coord-2', action: 'read', resource: 'Patient/robert-kim', outcome: 'denied' },
+  ],
+  total: 37,
+  limit: 20,
+  offset: 0,
+};
+
+// Deliberately NOT all-zero, so a tile that (wrongly) hardcodes "0" or "—"
+// instead of deriving from the query's data would fail these assertions,
+// EXCEPT confidenceDistribution below, which stays all-zero (today's honest
+// state per governance/service.ts) to prove the "—" / no-fabrication path too.
+const MOCK_MODEL: ModelPerformanceResult = {
+  analyses: [
+    { patientId: 'patient-a', modelVersion: 'gpt-5.5', createdTs: '2026-07-01T00:00:00.000Z' },
+    { patientId: 'patient-b', modelVersion: 'gpt-5.5', createdTs: '2026-07-02T00:00:00.000Z' },
+  ],
+  confidenceDistribution: [
+    { range: '0-0.5', count: 0 },
+    { range: '0.5-0.7', count: 0 },
+    { range: '0.7-0.85', count: 0 },
+    { range: '0.85-1.0', count: 0 },
+  ],
+};
+
+const MOCK_PARITY: ParityResult = {
+  byAgeBand: [
+    { group: '65+', patientCount: 2, avgRiskScore: 85 },
+    { group: '18-34', patientCount: 1, avgRiskScore: 15 },
+  ],
+  bySex: [{ group: 'female', patientCount: 3, avgRiskScore: 60 }],
+  byRace: [{ group: 'White', patientCount: 3, avgRiskScore: 60 }],
+  byEthnicity: [{ group: 'Not Hispanic or Latino', patientCount: 3, avgRiskScore: 60 }],
+};
+
+function renderGovernance() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <Governance />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Governance — W06 dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(client.getAuditTrail).mockResolvedValue(MOCK_AUDIT);
+    vi.mocked(client.getModelPerformance).mockResolvedValue(MOCK_MODEL);
+    vi.mocked(client.getParityMetrics).mockResolvedValue(MOCK_PARITY);
+    vi.mocked(client.getEvalSummary).mockResolvedValue({ available: false });
+  });
+
+  it('renders the banner title and an honest audited-events chip (not the mockups static Model/Regulatory chips)', async () => {
+    renderGovernance();
+    expect(await screen.findByRole('heading', { name: 'AI Governance Center' })).toBeInTheDocument();
+    expect(await screen.findByText(/37 audited events/)).toBeInTheDocument();
+    expect(screen.queryByText(/CareSync-v2\.3\.1/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Regulatory Posture/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Download Audit Report/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the Analyses Cached tile from the real analyses count', async () => {
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-tile-analyses-cached');
+    expect(within(tile).getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders "—" for Model Confidence (avg) when no confidence values exist yet, not a fabricated 0%', async () => {
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-tile-confidence-avg');
+    expect(within(tile).getByText('—')).toBeInTheDocument();
+    expect(within(tile).queryByText('0%')).not.toBeInTheDocument();
+  });
+
+  it('computes Model Confidence (avg) from real bucket data when it exists', async () => {
+    vi.mocked(client.getModelPerformance).mockResolvedValue({
+      analyses: MOCK_MODEL.analyses,
+      confidenceDistribution: [
+        { range: '0-0.5', count: 0 },
+        { range: '0.5-0.7', count: 0 },
+        { range: '0.7-0.85', count: 0 },
+        { range: '0.85-1.0', count: 4 },
+      ],
+    });
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-tile-confidence-avg');
+    expect(within(tile).getByText('93%')).toBeInTheDocument();
+  });
+
+  it('renders Flagged for Review from the lowest confidence bucket count', async () => {
+    vi.mocked(client.getModelPerformance).mockResolvedValue({
+      analyses: MOCK_MODEL.analyses,
+      confidenceDistribution: [
+        { range: '0-0.5', count: 3 },
+        { range: '0.5-0.7', count: 0 },
+        { range: '0.7-0.85', count: 0 },
+        { range: '0.85-1.0', count: 0 },
+      ],
+    });
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-tile-flagged');
+    expect(within(tile).getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders the audit trail entries most-recent-first with ts/actor/action/resource/outcome', async () => {
+    renderGovernance();
+    const trail = await screen.findByTestId('governance-audit-trail');
+    expect(within(trail).getByText(/coord-1/)).toBeInTheDocument();
+    expect(within(trail).getByText(/Patient\/maria-chen/)).toBeInTheDocument();
+    expect(within(trail).getByText(/coord-2/)).toBeInTheDocument();
+    // Not the mockup's fabricated per-entry fields (patient name, recommendation text, FHIR citation, confidence%).
+    expect(within(trail).queryByText(/Maria Chen/)).not.toBeInTheDocument();
+    expect(within(trail).queryByText(/%$/)).not.toBeInTheDocument();
+  });
+
+  it('pages the audit trail forward and back with Prev/Next, refetching with the new offset', async () => {
+    renderGovernance();
+    await screen.findByTestId('governance-audit-trail');
+    expect(client.getAuditTrail).toHaveBeenCalledWith(20, 0);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(client.getAuditTrail).toHaveBeenCalledWith(20, 20));
+
+    fireEvent.click(screen.getByRole('button', { name: /prev/i }));
+    await waitFor(() => expect(client.getAuditTrail).toHaveBeenCalledWith(20, 0));
+  });
+
+  it('renders the confidence chart and the raw analyses table (patientId/modelVersion/createdTs)', async () => {
+    renderGovernance();
+    const chart = await screen.findByTestId('governance-confidence-chart');
+    expect(chart.querySelector('canvas')).toBeInTheDocument();
+    expect(screen.getByText('patient-a')).toBeInTheDocument();
+    expect(screen.getAllByText('gpt-5.5').length).toBeGreaterThan(0);
+    // Dropped: no fabricated per-agent accuracy bars or version history.
+    expect(screen.queryByText(/Agent Accuracy by Type/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Model Version History/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the parity radar and the raw group-stat tables for all 4 dimensions', async () => {
+    renderGovernance();
+    const chart = await screen.findByTestId('governance-parity-chart');
+    expect(chart.querySelector('canvas')).toBeInTheDocument();
+    expect(screen.getByText('65+')).toBeInTheDocument();
+    expect(screen.getByText('White')).toBeInTheDocument();
+    // Dropped: no fabricated "Areas for Review" or "Compliance Attestations".
+    expect(screen.queryByText(/Areas for Review/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Compliance Attestations/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a loading state for the eval tile while the query is in flight', async () => {
+    vi.mocked(client.getEvalSummary).mockReturnValue(new Promise(() => {}));
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-eval-tile');
+    expect(within(tile).getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('shows a graceful empty state when the S9 report is not available yet', async () => {
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-eval-tile');
+    expect(within(tile).getByText(/not yet available.*S9/i)).toBeInTheDocument();
+  });
+
+  it('renders the eval summary headline when the report is available', async () => {
+    const available: EvalSummaryResult = { available: true, summary: { headline: 'Care Gap sensitivity 91%' } };
+    vi.mocked(client.getEvalSummary).mockResolvedValue(available);
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-eval-tile');
+    expect(within(tile).getByText(/Care Gap sensitivity 91%/)).toBeInTheDocument();
+  });
+
+  it('does not crash on an unexpected eval summary shape', async () => {
+    vi.mocked(client.getEvalSummary).mockResolvedValue({ available: true, summary: { totallyUnknownField: 42 } });
+    renderGovernance();
+    const tile = await screen.findByTestId('governance-eval-tile');
+    expect(tile).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Governance.tsx
+++ b/apps/web/src/pages/Governance.tsx
@@ -1,0 +1,315 @@
+import { useState } from 'react';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { getAuditTrail, getModelPerformance, getParityMetrics, getEvalSummary } from '../api/client';
+import { averageConfidence } from '../lib/confidenceChartGeometry';
+import { buildParityAxes } from '../lib/parityScore';
+import { ConfidenceChart } from '../components/ConfidenceChart';
+import { ParityRadarChart } from '../components/ParityRadarChart';
+
+/**
+ * W06 AI Governance Center (S8 Phase B) — real S8 A1-A3 aggregates rendered
+ * against `reference-materials/caresync-governance.html`'s structure (banner
+ * / zone 2 metric tiles / zone 3 three-column layout). This component owns
+ * only the `.main` content region, same convention as `Population.tsx` — the
+ * mockup's header/nav-rail chrome is already the app's real shell
+ * (`components/AppShell.tsx`).
+ *
+ * Documented deviations from the mockup (per CLAUDE.md's UI rules /
+ * html-mockup-fidelity skill — omit content the backend can't back yet
+ * rather than ship inert chrome):
+ * - Banner: dropped the "Model: CareSync-v2.3.1" chip (no model-version
+ *   string is tracked anywhere — `getModelPerformance()` returns a version
+ *   PER cached analysis, not one global "the model" version), "Regulatory
+ *   Posture: ... Compliant" chip, and "Download Audit Report" button (no
+ *   export endpoint exists). The one chip kept is an honest count of real
+ *   audited events (`auditQuery.data.total`).
+ * - Zone 2 tiles: "Analyses Run (30d)" (no time-windowed count exists;
+ *   replaced with "Analyses Cached," a real, honestly-labeled count of
+ *   `ModelPerformanceResult.analyses`). "Model Confidence (avg)" is real but
+ *   approximated: the API only returns bucketed counts, not raw per-finding
+ *   confidence values, so this is a count-weighted average of bucket
+ *   midpoints (`confidenceChartGeometry.ts`'s `averageConfidence`, itself
+ *   documented there) — renders "—" (not a fabricated 0%) whenever every
+ *   bucket is empty, which is true today (no agent emits a confidence field
+ *   yet — see `governance/service.ts`'s deviation note). "Flagged for
+ *   Review" is real: the count of findings in the lowest (`0-0.5`) confidence
+ *   bucket, same "auto-flagged" framing the mockup uses at a different
+ *   threshold. "Demographic Parity Score" is replaced with a clearly-labeled
+ *   average of the 4 real per-dimension parity values computed in
+ *   `parityScore.ts` (also driving the radar below) — not the mockup's
+ *   single fabricated 0.94.
+ * - Column A (Audit Trail): real, from `getAuditTrail()`, most-recent-first,
+ *   paged via limit/offset (Prev/Next). Renders only the real row shape
+ *   (`ts`/`actor`/`action`/`resource`/`outcome`) — the mockup's per-entry
+ *   patient name, natural-language recommendation text, FHIR citation, and
+ *   confidence% don't exist on the real `audit_log` row and are not
+ *   fabricated here.
+ * - Column B (Model Performance): `ConfidenceChart` (real 4-bucket
+ *   distribution) plus a raw `analyses` table (patientId/modelVersion/
+ *   createdTs). Dropped entirely: "Agent Accuracy by Type" (no per-agent
+ *   sensitivity/specificity/accuracy numbers exist anywhere in this system)
+ *   and "Model Version History" (no version-history data exists) — both
+ *   would be 100% fabricated if ported.
+ * - Column C (Demographic Equity Monitor): `ParityRadarChart` (4 real axes —
+ *   see `parityScore.ts`'s `buildParityAxes` doc for why Payer Type/
+ *   Geography/Language were dropped rather than faked) plus the raw
+ *   byAgeBand/bySex/byRace/byEthnicity group-stat tables. Dropped entirely:
+ *   "Areas for Review" (hardcoded language/payer-type flags with no backing
+ *   data) and "Compliance Attestations" (claiming formal HIPAA/FHIR-
+ *   conformance "Compliant" status nobody has attested to).
+ * - Zone 4 footer (framework badges + "Export Full Audit Log"): dropped
+ *   entirely — no export endpoint, and framework-mapping claims are the same
+ *   fabrication problem as the attestations above.
+ * - Eval headline tile (S8 B2): calls `getEvalSummary()`. S9 (the JSON
+ *   summary producer) doesn't exist on this branch, so `available` is always
+ *   `false` today — rendered as a graceful, clearly-labeled empty state
+ *   ("Evaluation report not yet available — coming with S9"), same
+ *   `PlaceholderPanel` convention `Population.tsx` uses for its own
+ *   not-yet-built panels, never a fabricated number.
+ */
+
+const AUDIT_PAGE_LIMIT = 20;
+
+// The 4 fixed bucket ranges `governance/service.ts`'s CONFIDENCE_BUCKETS
+// emits — the lowest one is the "unreliable, unfit to act on" band that
+// service's own doc comment calls out, so it doubles as this tile's
+// "Flagged for Review" definition (a real count, not a fabricated one).
+const LOWEST_CONFIDENCE_BUCKET = '0-0.5';
+
+function Tile({ value, label, note, valueClassName = 'text-cyan', testId }: {
+  value: string;
+  label: string;
+  note?: string;
+  valueClassName?: string;
+  testId?: string;
+}) {
+  return (
+    <div className="bg-surface border border-border rounded-card px-3.5 py-2.5 flex flex-col justify-center gap-0.5 min-w-0" data-testid={testId}>
+      <span className="text-xs font-semibold uppercase tracking-wide text-text-muted truncate">{label}</span>
+      <span className={`text-title font-bold font-mono leading-tight ${valueClassName}`}>{value}</span>
+      {note && <span className="text-xs text-text-dim truncate">{note}</span>}
+    </div>
+  );
+}
+
+function GroupStatTable({ title, groups }: { title: string; groups: { group: string; patientCount: number; avgRiskScore: number }[] }) {
+  return (
+    <div>
+      <div className="text-xs font-bold uppercase tracking-wide text-text-muted mb-1">{title}</div>
+      {groups.length === 0 && <p className="text-xs text-text-dim italic">No populated groups.</p>}
+      {groups.length > 0 && (
+        <table className="w-full text-xs font-mono">
+          <tbody>
+            {groups.map((g) => (
+              <tr key={g.group} className="border-t border-border">
+                <td className="py-1 pr-2 text-text truncate max-w-[9rem]">{g.group}</td>
+                <td className="py-1 pr-2 text-text-dim">n={g.patientCount}</td>
+                <td className="py-1 text-text-muted text-right">avg risk {g.avgRiskScore}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+/** Renders whatever headline field(s) make sense from the S9 JSON, defensively — S9's exact shape isn't defined yet, so this must not crash on an unexpected one. */
+function EvalSummaryContent({ summary }: { summary: unknown }) {
+  if (summary && typeof summary === 'object' && typeof (summary as Record<string, unknown>).headline === 'string') {
+    return <p className="text-body text-text">{(summary as Record<string, unknown>).headline as string}</p>;
+  }
+  return <pre className="text-xs text-text-muted whitespace-pre-wrap break-words">{JSON.stringify(summary, null, 2)}</pre>;
+}
+
+export function Governance() {
+  const [offset, setOffset] = useState(0);
+
+  const auditQuery = useQuery({
+    queryKey: ['governance-audit', offset],
+    queryFn: () => getAuditTrail(AUDIT_PAGE_LIMIT, offset),
+    // Keeps the previously-loaded page (and the Prev/Next controls) mounted
+    // while a new offset's page is in flight, instead of falling back to the
+    // page-level loading state on every click — pagination should feel like
+    // paging, not a full reload.
+    placeholderData: keepPreviousData,
+  });
+  const modelQuery = useQuery({ queryKey: ['governance-model'], queryFn: getModelPerformance });
+  const parityQuery = useQuery({ queryKey: ['governance-parity'], queryFn: getParityMetrics });
+  const evalQuery = useQuery({ queryKey: ['governance-eval'], queryFn: getEvalSummary });
+
+  const isLoading = auditQuery.isLoading || modelQuery.isLoading || parityQuery.isLoading;
+  const isError = auditQuery.isError || modelQuery.isError || parityQuery.isError;
+
+  const audit = auditQuery.data;
+  const model = modelQuery.data;
+  const parity = parityQuery.data;
+
+  const avgConfidence = model ? averageConfidence(model.confidenceDistribution) : undefined;
+  const flaggedCount = model?.confidenceDistribution.find((b) => b.range === LOWEST_CONFIDENCE_BUCKET)?.count ?? 0;
+  const parityAxes = parity ? buildParityAxes(parity) : [];
+  const avgParity = parityAxes.length > 0 ? parityAxes.reduce((sum, a) => sum + a.value, 0) / parityAxes.length : undefined;
+
+  return (
+    <div>
+      <h1 className="text-section text-text font-bold mb-4">AI Governance Center</h1>
+
+      {isLoading && <p className="text-body text-text-muted">Loading governance data…</p>}
+      {isError && <p className="text-body text-red">Could not load the governance dashboard.</p>}
+
+      {!isLoading && !isError && audit && model && parity && (
+        <div className="flex flex-col gap-2.5">
+          {/* ZONE 1 · banner */}
+          <section className="flex items-center gap-2 bg-surface-raised border border-border rounded-card px-4 py-3">
+            <span className="text-body font-bold text-text mr-auto">AI Governance Center</span>
+            <span className="text-xs font-bold rounded-pill px-2.5 py-1 bg-cyan-dim border border-cyan text-cyan whitespace-nowrap">
+              {audit.total} audited events
+            </span>
+          </section>
+
+          {/* ZONE 2 · metric tiles */}
+          <section className="grid grid-cols-4 gap-2.5">
+            <Tile testId="governance-tile-analyses-cached" label="Analyses Cached" value={String(model.analyses.length)} valueClassName="text-cyan" />
+            <Tile
+              testId="governance-tile-confidence-avg"
+              label="Model Confidence (avg)"
+              value={avgConfidence === undefined ? '—' : `${Math.round(avgConfidence * 100)}%`}
+              valueClassName="text-cyan"
+              note={avgConfidence === undefined ? 'No confidence values reported yet' : undefined}
+            />
+            <Tile
+              testId="governance-tile-flagged"
+              label="Flagged for Review"
+              value={String(flaggedCount)}
+              valueClassName="text-amber"
+              note="Findings below 50% confidence"
+            />
+            <Tile
+              testId="governance-tile-parity-avg"
+              label="Parity (avg of 4 derived scores)"
+              value={avgParity === undefined ? '—' : avgParity.toFixed(2)}
+              valueClassName="text-emerald"
+              note="1.0 = perfect parity"
+            />
+          </section>
+
+          {/* ZONE 3 · three columns */}
+          <section className="flex-1 flex gap-2.5 min-h-0">
+            {/* COLUMN A — Audit Trail */}
+            <div className="flex-[1.2] bg-surface border border-border rounded-card flex flex-col min-w-0">
+              <div className="flex items-center gap-2 px-3.5 py-2.5 border-b border-border">
+                <span className="text-body font-semibold text-text">Recommendation Audit Trail</span>
+                <span className="text-xs text-text-muted ml-auto">Every FHIR read/write, most recent first</span>
+              </div>
+              <div className="flex-1 overflow-y-auto" data-testid="governance-audit-trail">
+                {audit.entries.length === 0 && <p className="text-label text-text-dim italic px-3.5 py-3">No audit events yet.</p>}
+                {audit.entries.map((entry, i) => (
+                  <div key={`${entry.ts}-${i}`} className="px-3.5 py-2 border-b border-border last:border-b-0">
+                    <div className="flex items-baseline gap-2 min-w-0">
+                      <span className="font-mono text-xs text-text-dim flex-none">{entry.ts}</span>
+                      <span className="text-label font-bold text-text flex-none">{entry.actor}</span>
+                      <span className="text-xs font-bold uppercase tracking-wide text-text-muted flex-none">{entry.action}</span>
+                      <span
+                        className={`ml-auto text-xs font-bold uppercase tracking-wide flex-none ${
+                          entry.outcome === 'success' ? 'text-emerald' : entry.outcome === 'denied' ? 'text-red' : 'text-amber'
+                        }`}
+                      >
+                        {entry.outcome}
+                      </span>
+                    </div>
+                    <div className="font-mono text-xs text-text-muted mt-0.5 truncate">{entry.resource}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center justify-between px-3.5 py-2 border-t border-border">
+                <button
+                  type="button"
+                  onClick={() => setOffset((o) => Math.max(0, o - AUDIT_PAGE_LIMIT))}
+                  disabled={offset === 0}
+                  className="text-label text-cyan disabled:text-text-dim disabled:cursor-not-allowed hover:underline"
+                >
+                  Prev
+                </button>
+                <span className="text-xs text-text-dim">
+                  {audit.entries.length === 0 ? 0 : offset + 1}-{offset + audit.entries.length} of {audit.total}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setOffset((o) => o + AUDIT_PAGE_LIMIT)}
+                  disabled={offset + AUDIT_PAGE_LIMIT >= audit.total}
+                  className="text-label text-cyan disabled:text-text-dim disabled:cursor-not-allowed hover:underline"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+
+            {/* COLUMN B — Model Performance */}
+            <div className="flex-1 bg-surface border border-border rounded-card flex flex-col min-w-0">
+              <div className="px-3.5 py-2.5 border-b border-border">
+                <span className="text-body font-semibold text-text">Model Performance</span>
+                <div className="text-xs text-text-muted mt-0.5">Confidence distribution ({model.analyses.length} cached analyses)</div>
+              </div>
+              <div className="flex-1 flex flex-col gap-2.5 p-3.5 min-h-0 overflow-y-auto">
+                <div className="h-[140px] flex-none" data-testid="governance-confidence-chart">
+                  <ConfidenceChart buckets={model.confidenceDistribution} />
+                </div>
+                <div>
+                  <div className="text-xs font-bold uppercase tracking-wide text-text-muted mb-1">Cached Analyses</div>
+                  {model.analyses.length === 0 && <p className="text-xs text-text-dim italic">No cached analyses yet.</p>}
+                  {model.analyses.length > 0 && (
+                    <table className="w-full text-xs font-mono">
+                      <tbody>
+                        {model.analyses.map((a) => (
+                          <tr key={a.patientId} className="border-t border-border">
+                            <td className="py-1 pr-2 text-text truncate">{a.patientId}</td>
+                            <td className="py-1 pr-2 text-text-muted">{a.modelVersion}</td>
+                            <td className="py-1 text-text-dim text-right">{a.createdTs}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* COLUMN C — Demographic Equity Monitor */}
+            <div className="flex-1 bg-surface border border-border rounded-card flex flex-col min-w-0">
+              <div className="px-3.5 py-2.5 border-b border-border">
+                <span className="text-body font-semibold text-text">Demographic Equity Monitor</span>
+                <div className="text-xs text-text-muted mt-0.5">Parity derived from real cached risk scores × HAPI demographics</div>
+              </div>
+              <div className="flex-1 flex flex-col gap-2.5 p-3.5 min-h-0 overflow-y-auto">
+                <div className="h-[160px] flex-none" data-testid="governance-parity-chart">
+                  <ParityRadarChart axes={parityAxes} />
+                </div>
+                <GroupStatTable title="By Age Band" groups={parity.byAgeBand} />
+                <GroupStatTable title="By Sex" groups={parity.bySex} />
+                <GroupStatTable title="By Race" groups={parity.byRace} />
+                <GroupStatTable title="By Ethnicity" groups={parity.byEthnicity} />
+              </div>
+            </div>
+          </section>
+
+          {/* Eval headline tile (S8 B2) — separate, clearly-labeled panel. */}
+          <section className="bg-surface border border-border rounded-card flex flex-col min-w-0" data-testid="governance-eval-tile">
+            <div className="flex items-center gap-2 px-3.5 py-2.5 border-b border-border">
+              <span className="text-body font-semibold text-text">Evaluation Report (S9)</span>
+            </div>
+            <div className="px-3.5 py-3">
+              {evalQuery.isLoading && <p className="text-label text-text-muted">Loading evaluation report…</p>}
+              {evalQuery.isError && <p className="text-label text-red">Could not load the evaluation report.</p>}
+              {!evalQuery.isLoading && !evalQuery.isError && evalQuery.data && !evalQuery.data.available && (
+                <p className="text-label text-text-dim italic">Evaluation report not yet available — coming with S9.</p>
+              )}
+              {!evalQuery.isLoading && !evalQuery.isError && evalQuery.data?.available && (
+                <EvalSummaryContent summary={evalQuery.data.summary} />
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/plans/caresync-ai/implementation-plan.md
+++ b/docs/plans/caresync-ai/implementation-plan.md
@@ -485,28 +485,28 @@ Task writes audited + reversible via HAPI reset. The GD4 decision is recorded be
 
 ### Phase A — Governance aggregates (backend, test-first)
 
-- [ ] **A1. Audit trail endpoint.** `GET /api/governance/audit` paging the S1 `audit_log` (ts, actor, action, resource, outcome).
+- [x] **A1. Audit trail endpoint.** `GET /api/governance/audit` paging the S1 `audit_log` (ts, actor, action, resource, outcome).
   - *Domain rule:* live audit trail of every FHIR read/write with timestamp + user (story 15); reuses the S1 spine.
   - *Test (Supertest):* after some reads/writes, the trail lists them with actor + timestamp.
 
-- [ ] **A2. Model performance + confidence distribution.** `GET /api/governance/model` → model version + timestamp per analysis and a confidence distribution derived from S4 cached agent outputs.
+- [x] **A2. Model performance + confidence distribution.** `GET /api/governance/model` → model version + timestamp per analysis and a confidence distribution derived from S4 cached agent outputs.
   - *Domain rule:* each analysis shows model version + timestamp (story 12); confidence distribution derived from actual outputs (S8 acceptance).
   - *Test:* distribution computed from seeded cache rows matches expected buckets.
 
-- [ ] **A3. Demographic parity (computed — GD12).** `GET /api/governance/parity` → risk scores stratified by age/sex/race/ethnicity, joining cached analyses to real Synthea demographics from HAPI.
+- [x] **A3. Demographic parity (computed — GD12).** `GET /api/governance/parity` → risk scores stratified by age/sex/race/ethnicity, joining cached analyses to real Synthea demographics from HAPI.
   - *Domain rule:* parity computed from real Synthea demographics, not static (GD12, story 14).
   - *Test (Supertest vs test HAPI):* strata reflect the seeded demographics; a known-imbalanced fixture yields the expected disparity direction.
 
 ### Phase B — W06 Governance view (frontend, mockup fidelity)
 
-- [ ] **B1. W06 port (`reference-materials/caresync-governance.html`).** Audit trail table, Model Performance (`#confChart`), Demographic Equity Monitor (`#radarChart`) — native Canvas (GD10) — from A1–A3. ≥80% fidelity.
-- [ ] **B2. Eval headline tile (graceful placeholder).** Reads the S9 JSON summary if present, else an empty/loading state.
+- [x] **B1. W06 port (`reference-materials/caresync-governance.html`).** Audit trail table, Model Performance (`#confChart`), Demographic Equity Monitor (`#radarChart`) — native Canvas (GD10) — from A1–A3. ≥80% fidelity. Also added a tiny `GET /api/governance/eval` endpoint (reads `docs/eval-report.json` if present) needed to back B2.
+- [x] **B2. Eval headline tile (graceful placeholder).** Reads the S9 JSON summary if present, else an empty/loading state.
   - *Domain rule:* eval tile renders graceful empty/loading until S9 provides data (S8 acceptance) — honest staging.
   - *Test (Vitest):* renders parity/confidence/audit from data; eval tile shows empty state with no S9 data and the headline once present.
 
 ### Phase C — Verification
-- [ ] **C1.** `npm run test:api` (audit/model/parity) + `npm run test:web`.
-- [ ] **C2. Frontend E2E (`frontend-e2e-verification`).** Director → W06 → audit rows, model version, confidence chart, parity radar all render from real data; eval tile shows its empty state.
+- [x] **C1.** `npm run test:api` (audit/model/parity/eval) + `npm run test:web`.
+- [x] **C2. Frontend E2E (`frontend-e2e-verification`).** Director → W06 → audit rows, model version, confidence chart, parity radar all render from real data; eval tile shows its empty state.
 
 ### Rollback / safety
 All reads over existing SQLite + HAPI — no new writable state. Parity/confidence are computed at request time (no cache to invalidate). The eval tile never fabricates numbers (honest staging).

--- a/docs/plans/caresync-ai/review-s8.md
+++ b/docs/plans/caresync-ai/review-s8.md
@@ -1,0 +1,90 @@
+# Code Review — CareSync AI, S8 (AI Governance & audit dashboard, W06)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S8 · **Date:** 2026-07-06
+> **Diff:** `main` (`1701001`) `...HEAD` (`6267623` at review time), 3 commits.
+> **Spec sources:** `docs/plans/caresync-ai/issues.md` S8, `implementation-plan.md` Iteration 8,
+> `verification-s8.md`. This repo has no `CODING_STANDARDS.md`/`CONTRIBUTING.md` and `CLAUDE.md`'s
+> "Code style" section is an empty placeholder — the Standards axis instead measured the diff against
+> the closest established sibling module (`population/service.ts` + `routes/population.ts`, S5's
+> Director-only aggregate pattern) plus the fixed Fowler smell baseline. Prior review preserved at
+> `review-s7.md` (S1–S7 cumulative).
+
+## Standards
+
+**Convention match: strong.** `governance/service.ts`/`routes/governance.ts` closely mirror
+`population/service.ts`/`routes/population.ts` — same `assertDirector` shape (role check → denial
+audit → throw `DirectorOnlyError`), same single-error-type → 403 mapping, same doc-comment density
+explaining *why* (POC assumptions, deviation notes, honest-empty-state framing). `fhir/client.ts`'s
+new `getPatientDemographics` follows `getPopulationRiskProfile`'s bulk-read/single-audit pattern and
+reuses the existing `'demographic'` scope domain rather than inventing one. `apps/web/src/api/client.ts`
+additions match the file's existing doc-comment-per-interface style. `Governance.tsx` follows
+`Population.tsx`'s "own only `.main`" convention and documents every intentional mockup deviation.
+
+**Hard finding, fixed during this review:** `governance/service.ts` had more pure logic than
+`population/service.ts` (`bucketFor`, `stratify`, `ageFromBirthDate`, `extractConfidences`) but, unlike
+`population/service.ts`'s `projectedCostAvoidance` (which has its own `service.test.ts` "so it's
+unit-testable against a fixed fixture"), none of it had a direct unit test — boundary cases (confidence
+exactly 0.5/0.7/0.85, a birthdate landing exactly on today's month/day) were only incidentally covered
+via HTTP fixtures. **Fixed**: exported all four helpers and added
+`apps/api/src/governance/service.test.ts` (15 tests covering every stated boundary + the
+skip-undefined-group rule + empty-input cases). Re-verified: `tsc --noEmit` clean, 176/176 API tests
+pass (commit `249a9af`).
+
+**Baseline smell found, left as-is (judgement call, not fixed):** Duplicated Code — the identical
+try/catch → `DirectorOnlyError`/`ScopeDeniedError` → 403 block appears 4x verbatim in
+`routes/governance.ts` (audit/model/parity/eval), extending a pattern `population.ts` already
+establishes at 2 sites. Not new duplication shape, and refactoring it here (e.g. a
+`withDirectorErrorMapping(handler)` wrapper) would leave `population.ts` inconsistent with it unless
+also refactored — out of scope for this slice. Left as a documented judgement call rather than fixed
+unilaterally; worth revisiting if a fifth Director-only router is added.
+
+Not flagged, considered and dismissed: the 4x route-handler shape above also isn't a Shotgun Surgery
+risk in practice yet (all 4 handlers changed together, in the same commit, when this module was
+authored — the risk is hypothetical, not observed); `extractOmbCategoryDisplay`'s `any` usage matches
+existing untyped-FHIR-resource conventions elsewhere in `client.ts`; `parseNonNegativeInt` is a stated,
+deliberate new pagination convention (no prior list endpoint paginates), not a silent deviation;
+`Governance.tsx`'s 315 lines are comment-heavy mockup-deviation documentation, not unexplained
+complexity.
+
+## Spec
+
+**Verdict: clean.** No missing/partial requirements, no scope creep, no wrong-implementation findings
+survive verification.
+
+- **Phase A test rigor** (the area most worth checking closely): `routes/governance.test.ts` genuinely
+  satisfies the plan's specific bullets, not just happy-path/401/403. The `/model` test hand-computes
+  exact bucket counts from seeded confidences (plan A2: *"distribution computed from seeded cache rows
+  matches expected buckets"*). The `/parity` test seeds a real, deliberately-imbalanced HAPI fixture and
+  asserts the Black/female/65+ group's avg risk exceeds the White/male/18-34 group's (plan A3: *"a
+  known-imbalanced fixture yields the expected disparity direction"*). This review's own fix (above)
+  closes the one remaining gap — pure-function boundary cases weren't previously pinned directly.
+- **Phase B ≥80% fidelity bar**: `Governance.tsx`'s header comment enumerates every dropped mockup
+  element with a stated no-backing-data reason; structural regions (banner / 4-tile zone-2 / 3-column
+  zone-3, native Canvas per GD10) are preserved. Estimate (~80-85%) is plausible and not contradicted
+  by the diff.
+- **Phase C verification claims**: `apps/web/e2e/director-governance.spec.ts` exists and covers exactly
+  what `verification-s8.md` claims (login → nav → audit rows / model version / confidence canvas /
+  parity canvas / eval empty-state), against real `data-testid`s in `Governance.tsx`.
+- **GD10 (native Canvas, no chart library)**: confirmed — `ConfidenceChart.tsx`/`ParityRadarChart.tsx`
+  import only React hooks and draw via `<canvas>` directly.
+- **Director-only gating, routing, nav**: `App.tsx`'s `/governance` is `RoleGuard role="director"`;
+  `AppShell.tsx`'s nav link only renders for `user.role === 'director'`; `assertDirector` denies
+  non-Directors with an audit row — matching every A1–A3/B acceptance bullet in `issues.md`.
+- **The two pre-disclosed deviations** (no `confidence` field on agent outputs; underspecified
+  eval-JSON path) are both real and honestly handled, not silently degraded — `extractConfidences`
+  reads an optional runtime field with no fabrication; `EVAL_REPORT_PATH` resolves to
+  `docs/eval-report.json`, consistently referenced by both the endpoint and its test, and documents the
+  contract S9 must honor.
+
+No discrepancies found between `verification-s8.md`'s narrative and the actual diff contents.
+
+## Summary
+
+**Standards:** 1 hard finding (fixed in this review — missing unit tests for pure helpers), 1 baseline
+smell (judgement call, left as-is — duplicated error-mapping block, matches an existing 2x pattern
+extended to 4x). Worst issue: the missing-unit-test gap, now closed.
+**Spec:** 0 findings. Worst issue: none.
+
+## Next step
+
+`finishing-a-development-branch` — push, open the PR against `main`, and merge.

--- a/docs/plans/caresync-ai/verification-s8.md
+++ b/docs/plans/caresync-ai/verification-s8.md
@@ -1,0 +1,159 @@
+# Verification — CareSync AI, S8 (AI Governance & audit dashboard, W06)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S8 · **Date:** 2026-07-06
+> **Stage:** Phase 5 (`verification-before-completion`), run on `feature/caresync-s8-governance-dashboard`
+> (base `1701001` = `main`, tip `729331f`, 2 commits: `df46f4c` Phase A — governance aggregates,
+> `729331f` Phase B — W06 governance view). Read `docs/plans/caresync-ai/implementation-plan.md`
+> Iteration 8 and `docs/plans/caresync-ai/issues.md` S8 for the plan this verifies against — not
+> re-derived here. Built via `subagent-driven-development`: one implementer subagent per phase, one
+> independent reviewer subagent per phase (not the implementer grading its own work), both re-verified
+> again in this consolidated pass.
+
+## 1. Fresh command evidence (this session, 2026-07-06)
+
+Every command below was re-run fresh in this final pass, on top of the per-phase reviewer's own
+independent run (§4) — not trusted from either subagent's self-report. Local stack: Docker HAPI FHIR
+already running and healthy, API + web dev servers via Playwright's `webServer` config.
+
+| Command | Result |
+|---|---|
+| `cd apps/api && npx jest --runInBand` | **28 suites / 161 tests passed** |
+| `cd apps/web && npx vitest run` | **19 files / 177 tests passed** |
+| `cd apps/web && npx playwright test --workers=1` | **14/14 specs passed** (incl. new `director-governance.spec.ts`) |
+| `cd apps/api && npx tsc --noEmit` | exit 0 |
+| `cd apps/web && npx tsc --noEmit` | exit 0 |
+
+No flakiness observed in this pass. (S3–S7's documented parallel-Jest-vs-shared-HAPI contention is an
+existing environmental note, not re-triggered here — `--runInBand` was used throughout, same as S7.)
+
+## 2. Definition-of-done check (S8 acceptance, `issues.md`)
+
+All 6 acceptance bullets confirmed against the actual code and this session's live evidence:
+
+1. **Audit trail lists real logged FHIR reads/writes with timestamp + user** —
+   `GET /api/governance/audit` (`governance/service.ts` `getAuditTrail` → `db/audit.ts`
+   `readAuditTrail`) pages the real S1 `audit_log` table, most-recent-first (`ORDER BY id DESC`),
+   Director-only. Confirmed live in `director-governance.spec.ts`: real success/denied rows render
+   with actor + timestamp.
+2. **Each analysis shows its model version and timestamp** — `GET /api/governance/model`
+   (`getModelPerformance`) reads every `analysis_cache` row via the new `readAllAnalysisCache` and
+   returns `{patientId, modelVersion, createdTs}` per cached analysis. Rendered as a raw table in
+   `Governance.tsx`'s Model Performance column.
+3. **Confidence distribution is derived from actual agent outputs** — `getModelPerformance` buckets
+   real per-finding `confidence` values (when present) into 4 documented ranges. **Known honest gap**:
+   no agent (`riskAgent`/`careGapAgent`/`sdohAgent`) currently emits a `confidence` field on any
+   finding (confirmed by grep across `apps/api/src/agents/`), so all buckets are 0 today. This was
+   caught by the Phase A implementer, independently confirmed true by the Phase A reviewer, and
+   re-confirmed here — it is documented in `governance/service.ts`'s deviation-note comment and
+   surfaces honestly (all-zero bars) rather than fabricating a number. The endpoint is
+   forward-compatible with no migration once an agent starts reporting confidence.
+4. **Parity metrics are computed from Synthea demographics, not static numbers** — `GET
+   /api/governance/parity` (`getParityMetrics`, GD12) joins every cached analysis's
+   `result_json.risk.complete.riskScore` to that patient's live HAPI `Patient.birthDate`/`gender`/
+   US-Core race+ethnicity extensions (`FhirReadService.getPatientDemographics`, a new scoped `_id=`
+   batch fetch), then stratifies by age band/sex/race/ethnicity. Test seeds real, distinguishable HAPI
+   patients and asserts both exact per-group averages and disparity direction, not a weak assertion.
+5. **Eval tile renders a graceful empty/loading state until S9 provides data** — new
+   `GET /api/governance/eval` reads `docs/eval-report.json` if present, else returns
+   `{available:false}` (never throws, never fabricates). `docs/eval-report.json` does not exist yet
+   (confirmed absent from the repo), so the tile is currently, correctly, always in its empty state —
+   confirmed live in `director-governance.spec.ts` ("not yet available").
+6. **API-boundary tests for the audit/parity endpoints** — `apps/api/src/routes/governance.test.ts`
+   covers all four endpoints (audit/model/parity/eval), each with a happy path, a 403 (non-Director),
+   and a 401 (unauthenticated) case — 14 tests total, all passing in §1.
+
+No drift between what's claimed done and what the code does.
+
+## 3. Spec-drift check (issues.md / implementation-plan.md vs. code)
+
+One real plan-vs-reality mismatch, caught and resolved during implementation (not a silent deviation):
+
+- **The plan's "confidence distribution derived from actual agent outputs" assumes a `confidence`
+  field exists on agent findings — it doesn't (see §2.3).** Resolution: read `analysis_cache
+  .result_json` as loosely-typed JSON (already not constrained to `AgentFlag`'s TS shape at the DB
+  layer) and extract an *optional* per-finding `confidence: number` at runtime. This was treated as an
+  engineering resolution of a type/runtime mismatch, not a guess at an undocumented domain rule, and
+  is the honest choice under this slice's own "no fabrication" ponytail rule — the alternative
+  (fabricating plausible-looking confidence numbers, as the mockup's hardcoded demo data does) would
+  have violated it.
+
+- **The plan's B2 line ("reads the S9 JSON summary if present") implies a JSON file S9 will produce,
+  but doesn't name its path.** Resolution: a new minimal `GET /api/governance/eval` reads
+  `docs/eval-report.json` at the repo root, documented inline as the path S9's harness should write
+  to. This is additive, not a reinterpretation of committed plan text — S9 (not yet built) will need to
+  target this exact path, and that expectation is now recorded in code rather than only in this
+  document.
+
+Other checks:
+- **Mockup fidelity** — `reference-materials/caresync-governance.html`'s fabricated/unbacked sections
+  (Model/Regulatory-Posture chips, Download Audit Report button, Agent Accuracy bars, Model Version
+  History table, Areas for Review, Compliance Attestations, zone-4 framework footer, per-audit-entry
+  patient name/recommendation-text/FHIR-citation/confidence%) were deliberately dropped rather than
+  ported with invented numbers, each documented in `Governance.tsx`'s top-of-file comment — the same
+  convention `Population.tsx` (S5) established. Structural fidelity (banner / 4-tile zone-2 / 3-column
+  zone-3 with matching proportions, rounded-card/border-color visual language, native-canvas GD10
+  charts) is preserved. Estimated ~80-85%, at the CLAUDE.md-required ≥80% bar, with the gap entirely
+  accounted for by these documented, backend-data-driven omissions.
+- **`implementation-plan.md` Iteration 8's checkboxes** — A1-A3, B1-B2, C1-C2, and the
+  Definition-of-done bullets are all `[x]`, matching the actual committed state (verified by reading
+  the file directly, not trusting the implementer's claim).
+- **No new persisted state** — confirmed `apps/api/src/db/index.ts`'s `migrate()` is unchanged; the
+  three tables (`users`, `audit_log`, `analysis_cache`) are the same ones since S1/S4. The new eval
+  endpoint reads a file, not a table.
+- **Director-only gating** — `governance/service.ts`'s `assertDirector` is a deliberate, minimal
+  duplicate of `population/service.ts`'s (not imported — that one is module-private), same rule, same
+  denial-audit call, same `DirectorOnlyError`. `/governance` is `RoleGuard role="director"`-gated in
+  `App.tsx`; the nav link in `AppShell.tsx` only renders for `user.role === 'director'`.
+
+## 4. Review notes
+
+Both phases were built by an implementer subagent under an explicit TDD requirement (failing test
+first, confirmed red for the right reason, then green), and **each phase's implementer report was
+independently re-verified by a separate reviewer subagent** — not the same agent grading its own work,
+and not trusted at face value: the reviewer re-read the diffs, re-ran every test suite itself, and
+spot-checked specific claims (e.g., grepping for `confidence` across the agents directory to confirm
+Phase A's "field doesn't exist" claim; checking `docs/eval-report.json`'s absence to confirm Phase B's
+empty-state claim is currently guaranteed-true, not just handled). Both phases returned **APPROVE** —
+see the phase-by-phase review transcripts in this session. This consolidated pass re-ran the full
+suite + E2E one more time (§1) on top of both reviewers' independent runs, rather than relying solely
+on either subagent round.
+
+No `NEEDS_CONTEXT` escalations were needed in Phase A. Phase B had one ambiguity (which of the
+mockup's 6 radar axes to drop, given only 4 real data sources) that the implementer resolved correctly
+from the prompt's own next sentence rather than escalating — confirmed correct on review.
+
+## 5. Domain-term documentation check
+
+New domain concepts introduced by S8 — the `governance/` aggregate module (mirroring `population/`'s
+shape), `PatientDemographics` (age/sex/race/ethnicity derived from live HAPI reads), the
+confidence-bucket convention (`0-0.5/0.5-0.7/0.7-0.85/0.85-1.0`), the age-band convention
+(`<18/18-34/35-49/50-64/65+`), the per-dimension parity-score formula
+(`1 - (max avgRisk - min avgRisk) / max avgRisk`, clamped to `[0,1]`), and the `docs/eval-report.json`
+path convention for the future S9 handoff — are all documented inline via doc comments at their
+introduction point (`governance/service.ts`, `parityScore.ts`), consistent with the
+"Domain rule:"/deviation-note convention established since S2. `docs/agents/domain.md` and
+`docs/agents/issue-tracker.md` still don't exist — the same pre-existing, deferred gap noted in every
+prior slice's verification (S5, S7), unchanged by S8.
+
+## 6. Evidence-boundary labeling (CLAUDE.md)
+
+Per CLAUDE.md's evidence-boundaries rule: all evidence in this document is **local mock / packaged UI
+strength** — Jest/Vitest suites and headless Playwright runs against a local dev stack and the
+existing local Docker HAPI container. This proves the actual rendered UI, the actual FHIR/audit-log
+reads, and the actual demographic join work together — but it is **not** target-environment,
+client-accepted, or production-hardware evidence. No such claim is made here. The confidence
+distribution's all-zero state (§2.3) is an honest reflection of the current agent pipeline, not a
+verification gap — re-confirmed by grep, not assumed.
+
+## 7. Gate outcome
+
+**PASS.** All fresh command evidence is green (§1). Definition-of-done (§2) and spec-drift (§3) checks
+found one real plan-vs-reality mismatch (no `confidence` field exists on agent outputs) and one
+under-specified plan detail (eval-summary file path) — both resolved honestly during implementation
+(documented gap + a sensible, documented path convention) rather than papered over. No product-behavior
+defects remain open, and no fabricated/hardcoded demo numbers were found anywhere in the shipped
+`Governance.tsx` (confirmed independently by the Phase B reviewer and spot-checked again in this pass).
+
+## Next step
+
+`code-review`, covering the full branch diff since `main` along the Standards and Spec axes.


### PR DESCRIPTION
## Summary
- `GET /api/governance/audit|model|parity|eval` — real audit-log paging, a confidence distribution derived from cached agent outputs (honestly all-zero today since no agent yet emits a `confidence` field — documented, not hidden), and demographic parity computed from live HAPI Synthea demographics (GD12), plus a stateless eval-summary read for the future S9 handoff.
- W06 Governance screen: native-canvas (GD10) confidence-distribution bar chart and demographic-parity radar, a real audit trail, and a graceful eval-tile placeholder. Mockup content with no backing data (agent-accuracy bars, model version history, compliance attestations, framework footer) is intentionally dropped and documented rather than fabricated.
- Director-only route + nav link.

## Process
Built via `subagent-driven-development` — one implementer + one independent reviewer subagent per phase — plus `html-mockup-fidelity` (Phase B, ~80-85% fidelity) and `frontend-e2e-verification` (`director-governance.spec.ts`). Full `verification-before-completion` and two-axis `code-review` (Standards + Spec) passes completed; one Standards finding (missing unit tests for pure helpers) was fixed during review.

See `docs/plans/caresync-ai/verification-s8.md` and `review-s8.md` for full detail.

## Test plan
- [x] `npm run test:api` — 176/176 passed
- [x] `npm run test:web` — 177/177 passed
- [x] `npx playwright test --workers=1` — 14/14 passed (incl. new `director-governance.spec.ts`)
- [x] `tsc --noEmit` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)