### PR TITLE
feat(S9): Evaluation harness + report

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "lint": "eslint src",
     "import": "tsx src/scripts/import-fhir.ts",
+    "eval": "tsx src/scripts/eval.ts",
     "migrate": "tsx src/scripts/migrate.ts",
     "seed": "tsx src/db/seed.ts"
   },

--- a/apps/api/src/eval/computeMetrics.test.ts
+++ b/apps/api/src/eval/computeMetrics.test.ts
@@ -1,0 +1,179 @@
+import { computeMetrics, tallyConfusionMatrix, classificationMetricsFromMatrix, LabelRow, PatientFindings } from './computeMetrics';
+
+// Hand-built, fixed fixture (S9 A2 — Seam 4, TDD) — deliberately NOT derived
+// from data/eval/labels.json, so this test pins computeMetrics' arithmetic
+// against a known, hand-computed expected output, independent of any future
+// edit to the committed label file.
+//
+// p1: expected true/true/true, agent predicts true/true/true  -> agree everywhere
+// p2: expected false/false/false, agent predicts false/false/false -> agree everywhere
+// p3: expected true/false/true, agent predicts false/false/false -> careGap FN, risk TN, sdoh disagree
+// p4: expected false/true/false, agent predicts true/true/false -> careGap FP, risk TP, sdoh agree
+// p5: expected null/null/null (unlabeled — must be excluded from all three tallies)
+const labels: LabelRow[] = [
+  {
+    patientId: 'p1',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: true, notes: 'fixture' },
+    risk: { expectedHighRisk: true, notes: 'fixture' },
+    sdoh: { expectedHasBarrier: true, notes: 'fixture' },
+  },
+  {
+    patientId: 'p2',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: false, notes: 'fixture' },
+    risk: { expectedHighRisk: false, notes: 'fixture' },
+    sdoh: { expectedHasBarrier: false, notes: 'fixture' },
+  },
+  {
+    patientId: 'p3',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: true, notes: 'fixture' },
+    risk: { expectedHighRisk: false, notes: 'fixture' },
+    sdoh: { expectedHasBarrier: true, notes: 'fixture' },
+  },
+  {
+    patientId: 'p4',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: false, notes: 'fixture' },
+    risk: { expectedHighRisk: true, notes: 'fixture' },
+    sdoh: { expectedHasBarrier: false, notes: 'fixture' },
+  },
+  {
+    patientId: 'p5',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: null, notes: 'fixture — unlabeled' },
+    risk: { expectedHighRisk: null, notes: 'fixture — unlabeled' },
+    sdoh: { expectedHasBarrier: null, notes: 'fixture — unlabeled' },
+  },
+];
+
+const findings: PatientFindings[] = [
+  {
+    patientId: 'p1',
+    careGap: { findings: [{ gapType: 'HbA1c monitoring', description: 'x', urgency: 'high', fhirResourceId: 'Condition/1' }] },
+    risk: { findings: [], complete: { riskLevel: 'critical' } },
+    sdoh: { findings: [{ domain: 'housing', finding: 'x', severity: 'high', fhirResourceId: 'Observation/1' }] },
+    actionPlanner: { tasks: [{ id: 't1', title: 'Task A', description: 'x', priority: 'high', fhirResources: ['Condition/1'] }] },
+  },
+  {
+    patientId: 'p2',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'low' } },
+    sdoh: { findings: [] },
+    actionPlanner: { tasks: [] },
+  },
+  {
+    patientId: 'p3',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'moderate' } },
+    sdoh: { findings: [] },
+    // no actionPlanner entry — must be excluded from the notes pass-through
+  },
+  {
+    patientId: 'p4',
+    careGap: { findings: [{ gapType: 'BNP monitoring', description: 'x', urgency: 'medium', fhirResourceId: 'Condition/4' }] },
+    risk: { findings: [], complete: { riskLevel: 'high' } },
+    sdoh: { findings: [] },
+    // no actionPlanner entry — must be excluded from the notes pass-through
+  },
+  {
+    patientId: 'p5',
+    careGap: { findings: [{ gapType: 'irrelevant', description: 'x', urgency: 'low', fhirResourceId: 'Condition/5' }] },
+    risk: { findings: [], complete: { riskLevel: 'critical' } },
+    sdoh: { findings: [] },
+    actionPlanner: {
+      tasks: [
+        { id: 't2', title: 'Task B', description: 'x', priority: 'medium', fhirResources: ['Condition/5'] },
+        { id: 't3', title: 'Task C', description: 'x', priority: 'low', fhirResources: ['Condition/5'] },
+      ],
+    },
+  },
+];
+
+describe('tallyConfusionMatrix (Seam 4 helper)', () => {
+  it('tallies TP/TN/FP/FN from expected/predicted pairs', () => {
+    expect(
+      tallyConfusionMatrix([
+        { expected: true, predicted: true },
+        { expected: false, predicted: false },
+        { expected: true, predicted: false },
+        { expected: false, predicted: true },
+      ])
+    ).toEqual({ truePositive: 1, trueNegative: 1, falsePositive: 1, falseNegative: 1 });
+  });
+
+  it('returns all zeros for an empty input', () => {
+    expect(tallyConfusionMatrix([])).toEqual({ truePositive: 0, trueNegative: 0, falsePositive: 0, falseNegative: 0 });
+  });
+});
+
+describe('classificationMetricsFromMatrix (Seam 4 helper)', () => {
+  it('computes sensitivity/specificity/ppv from a balanced matrix', () => {
+    expect(
+      classificationMetricsFromMatrix({ truePositive: 1, trueNegative: 1, falsePositive: 1, falseNegative: 1 })
+    ).toEqual({ sensitivity: 0.5, specificity: 0.5, ppv: 0.5 });
+  });
+
+  it('returns null (not NaN/0) for a metric whose denominator is zero', () => {
+    expect(
+      classificationMetricsFromMatrix({ truePositive: 0, trueNegative: 0, falsePositive: 0, falseNegative: 0 })
+    ).toEqual({ sensitivity: null, specificity: null, ppv: null });
+  });
+});
+
+describe('computeMetrics (Seam 4 — S9 A2, pure, fixed fixture)', () => {
+  it('matches the hand-computed expected output exactly', () => {
+    const result = computeMetrics(labels, findings);
+
+    expect(result.careGap).toEqual({
+      sensitivity: 0.5,
+      specificity: 0.5,
+      ppv: 0.5,
+      matrix: { truePositive: 1, trueNegative: 1, falsePositive: 1, falseNegative: 1 },
+      labeledCount: 4,
+    });
+
+    expect(result.risk).toEqual({
+      sensitivity: 1,
+      specificity: 1,
+      ppv: 1,
+      matrix: { truePositive: 2, trueNegative: 2, falsePositive: 0, falseNegative: 0 },
+      labeledCount: 4,
+    });
+
+    expect(result.sdoh).toEqual({ agreementRate: 0.75, agreements: 3, total: 4 });
+
+    expect(result.actionPlanner.notes).toEqual([
+      { patientId: 'p1', taskCount: 1, taskTitles: ['Task A'] },
+      { patientId: 'p2', taskCount: 0, taskTitles: [] },
+      { patientId: 'p5', taskCount: 2, taskTitles: ['Task B', 'Task C'] },
+    ]);
+  });
+
+  it('excludes a patient with no findings entry at all from every dimension', () => {
+    const result = computeMetrics(
+      [
+        {
+          patientId: 'not-run',
+          source: 'dev',
+          clinicianOverride: null,
+          careGap: { expectedHasGap: true, notes: 'fixture' },
+          risk: { expectedHighRisk: true, notes: 'fixture' },
+          sdoh: { expectedHasBarrier: true, notes: 'fixture' },
+        },
+      ],
+      []
+    );
+
+    expect(result.careGap.labeledCount).toBe(0);
+    expect(result.risk.labeledCount).toBe(0);
+    expect(result.sdoh.total).toBe(0);
+    expect(result.actionPlanner.notes).toEqual([]);
+  });
+});

--- a/apps/api/src/eval/computeMetrics.ts
+++ b/apps/api/src/eval/computeMetrics.ts
@@ -128,7 +128,10 @@ export interface MetricsReport {
 
 // Risk agent's riskLevel enum values (riskAgent.ts's REPORT_RISK_TOOL schema)
 // treated as "high risk" for the binary classification this eval performs.
-const HIGH_RISK_LEVELS = new Set(['high', 'critical']);
+// Exported so errorAnalysis.ts shares this single definition of "high risk"
+// rather than re-deriving it — a threshold change (e.g. adding 'severe')
+// only needs to happen here.
+export const HIGH_RISK_LEVELS = new Set(['high', 'critical']);
 
 /**
  * Tallies expected/predicted boolean pairs into a confusion matrix. Exported

--- a/apps/api/src/eval/computeMetrics.ts
+++ b/apps/api/src/eval/computeMetrics.ts
@@ -1,0 +1,223 @@
+/**
+ * Seam 4 — S9 A2 (GD8). Pure evaluation-metric computation: no FHIR/HAPI/LLM
+ * I/O. Takes the committed ground-truth label rows (`data/eval/labels.json`,
+ * shape `LabelRow[]`) and the per-patient, already-VALIDATED agent findings
+ * (the same post-`validateCitations` shape the product surfaces to
+ * clinicians — see `routes/analysis.ts`'s `AnalysisResultJson`, not the raw
+ * orchestrator output; comparing against unvalidated findings would score the
+ * agents against citations the product never actually shows anyone) and
+ * computes sensitivity/specificity/PPV for Care Gap + Risk, an agreement rate
+ * for SDOH, and a qualitative pass-through for Action Planner.
+ *
+ * Domain rule: a label dimension of `null` means "no confident ground truth"
+ * (S9 A1 — an honest skip, not a fabricated guess) and that patient is
+ * excluded from that dimension's confusion matrix / agreement tally, but can
+ * still contribute to the other dimensions. A patient with no findings entry
+ * at all (the harness didn't run over them this cycle) is excluded from
+ * every dimension the same way, for the same reason — no run, no comparison.
+ */
+
+// --- label side (data/eval/labels.json row shape) ------------------------
+
+export interface CareGapLabel {
+  /** null = no confident ground truth for this patient (S9 A1 — honest skip). */
+  expectedHasGap: boolean | null;
+  notes: string;
+}
+
+export interface RiskLabel {
+  expectedHighRisk: boolean | null;
+  /** The seed/generator's own deterministic riskScore (0-100) this label was derived from, where applicable. */
+  seedRiskScore?: number;
+  notes: string;
+}
+
+export interface SdohLabel {
+  expectedHasBarrier: boolean | null;
+  expectedDomains?: string[];
+  notes: string;
+}
+
+export interface LabelRow {
+  patientId: string;
+  /** GD8: "dev" until a clinician reviews/overrides a row. */
+  source: 'dev' | 'clinician';
+  /** GD8 override slot — reserved for a future clinician-supplied correction; not read by computeMetrics today. */
+  clinicianOverride?: unknown;
+  careGap: CareGapLabel;
+  risk: RiskLabel;
+  sdoh: SdohLabel;
+  actionPlanner?: { notes?: string };
+}
+
+// --- findings side (post-validateCitations shapes, matching AnalysisResultJson) ---
+
+export interface CareGapFinding {
+  gapType: string;
+  description: string;
+  lastDone?: string;
+  dueDate?: string;
+  urgency: string;
+  fhirResourceId: string;
+}
+
+export interface SdohFinding {
+  domain: string;
+  finding: string;
+  severity: string;
+  fhirResourceId: string;
+}
+
+export interface ActionPlannerTask {
+  id: string;
+  title: string;
+  description: string;
+  priority: string;
+  fhirResources: string[];
+}
+
+export interface PatientFindings {
+  patientId: string;
+  /** Absent = the Care Gap agent didn't run (or produce a result) for this patient this cycle. */
+  careGap?: { findings: CareGapFinding[] };
+  /** Absent = the Risk agent didn't run for this patient this cycle. */
+  risk?: { findings: unknown[]; complete: { riskLevel: string } };
+  /** Absent = the SDOH agent didn't run for this patient this cycle. */
+  sdoh?: { findings: SdohFinding[] };
+  /** Absent = the Action Planner didn't run (or created no tasks) for this patient this cycle. */
+  actionPlanner?: { tasks: ActionPlannerTask[] };
+}
+
+// --- metric shapes ---------------------------------------------------------
+
+export interface ConfusionMatrix {
+  truePositive: number;
+  trueNegative: number;
+  falsePositive: number;
+  falseNegative: number;
+}
+
+export interface ClassificationMetrics {
+  /** null (not NaN/0) when the metric's denominator is zero — an honest "not computable," never a fabricated number. */
+  sensitivity: number | null;
+  specificity: number | null;
+  ppv: number | null;
+  matrix: ConfusionMatrix;
+  /** Number of patients that contributed to this matrix (i.e. had both a non-null label and a findings entry for this dimension). */
+  labeledCount: number;
+}
+
+export interface AgreementMetrics {
+  agreementRate: number | null;
+  agreements: number;
+  total: number;
+}
+
+export interface ActionPlannerNote {
+  patientId: string;
+  taskCount: number;
+  taskTitles: string[];
+}
+
+export interface MetricsReport {
+  careGap: ClassificationMetrics;
+  risk: ClassificationMetrics;
+  sdoh: AgreementMetrics;
+  actionPlanner: { notes: ActionPlannerNote[] };
+}
+
+// Risk agent's riskLevel enum values (riskAgent.ts's REPORT_RISK_TOOL schema)
+// treated as "high risk" for the binary classification this eval performs.
+const HIGH_RISK_LEVELS = new Set(['high', 'critical']);
+
+/**
+ * Tallies expected/predicted boolean pairs into a confusion matrix. Exported
+ * for direct unit testing (governance/service.ts's convention for
+ * otherwise-private pure helpers): the TP/TN/FP/FN branching is easy to pin
+ * exactly here, independent of computeMetrics' label/findings wiring.
+ */
+export function tallyConfusionMatrix(pairs: { expected: boolean; predicted: boolean }[]): ConfusionMatrix {
+  const matrix: ConfusionMatrix = { truePositive: 0, trueNegative: 0, falsePositive: 0, falseNegative: 0 };
+  for (const { expected, predicted } of pairs) {
+    if (expected && predicted) matrix.truePositive++;
+    else if (!expected && !predicted) matrix.trueNegative++;
+    else if (!expected && predicted) matrix.falsePositive++;
+    else matrix.falseNegative++;
+  }
+  return matrix;
+}
+
+/**
+ * Derives sensitivity/specificity/PPV from a confusion matrix. Exported for
+ * direct unit testing, same rationale as {@link tallyConfusionMatrix} — in
+ * particular the zero-denominator -> null behavior (never NaN, never a
+ * fabricated 0), which is awkward to pin through computeMetrics' full wiring.
+ */
+export function classificationMetricsFromMatrix(
+  matrix: ConfusionMatrix
+): { sensitivity: number | null; specificity: number | null; ppv: number | null } {
+  const { truePositive, trueNegative, falsePositive, falseNegative } = matrix;
+  const sensitivityDenom = truePositive + falseNegative;
+  const specificityDenom = trueNegative + falsePositive;
+  const ppvDenom = truePositive + falsePositive;
+  return {
+    sensitivity: sensitivityDenom > 0 ? truePositive / sensitivityDenom : null,
+    specificity: specificityDenom > 0 ? trueNegative / specificityDenom : null,
+    ppv: ppvDenom > 0 ? truePositive / ppvDenom : null,
+  };
+}
+
+/**
+ * Seam 4 (S9 A2) — pure. See module doc comment for the full contract.
+ */
+export function computeMetrics(labels: LabelRow[], findings: PatientFindings[]): MetricsReport {
+  const findingsByPatientId = new Map(findings.map((f) => [f.patientId, f]));
+
+  const careGapPairs: { expected: boolean; predicted: boolean }[] = [];
+  const riskPairs: { expected: boolean; predicted: boolean }[] = [];
+  let sdohAgreements = 0;
+  let sdohTotal = 0;
+  const actionPlannerNotes: ActionPlannerNote[] = [];
+
+  for (const label of labels) {
+    const patientFindings = findingsByPatientId.get(label.patientId);
+
+    if (label.careGap.expectedHasGap !== null && patientFindings?.careGap) {
+      careGapPairs.push({
+        expected: label.careGap.expectedHasGap,
+        predicted: patientFindings.careGap.findings.length > 0,
+      });
+    }
+
+    if (label.risk.expectedHighRisk !== null && patientFindings?.risk) {
+      riskPairs.push({
+        expected: label.risk.expectedHighRisk,
+        predicted: HIGH_RISK_LEVELS.has(patientFindings.risk.complete.riskLevel),
+      });
+    }
+
+    if (label.sdoh.expectedHasBarrier !== null && patientFindings?.sdoh) {
+      const predicted = patientFindings.sdoh.findings.length > 0;
+      sdohTotal++;
+      if (predicted === label.sdoh.expectedHasBarrier) sdohAgreements++;
+    }
+
+    if (patientFindings?.actionPlanner) {
+      actionPlannerNotes.push({
+        patientId: label.patientId,
+        taskCount: patientFindings.actionPlanner.tasks.length,
+        taskTitles: patientFindings.actionPlanner.tasks.map((t) => t.title),
+      });
+    }
+  }
+
+  const careGapMatrix = tallyConfusionMatrix(careGapPairs);
+  const riskMatrix = tallyConfusionMatrix(riskPairs);
+
+  return {
+    careGap: { ...classificationMetricsFromMatrix(careGapMatrix), matrix: careGapMatrix, labeledCount: careGapPairs.length },
+    risk: { ...classificationMetricsFromMatrix(riskMatrix), matrix: riskMatrix, labeledCount: riskPairs.length },
+    sdoh: { agreementRate: sdohTotal > 0 ? sdohAgreements / sdohTotal : null, agreements: sdohAgreements, total: sdohTotal },
+    actionPlanner: { notes: actionPlannerNotes },
+  };
+}

--- a/apps/api/src/eval/errorAnalysis.test.ts
+++ b/apps/api/src/eval/errorAnalysis.test.ts
@@ -1,0 +1,171 @@
+import { computeErrorAnalysis } from './errorAnalysis';
+import { LabelRow, PatientFindings } from './computeMetrics';
+
+// Hand-built fixture (S9 B1 — TDD), deliberately separate from
+// computeMetrics.test.ts's fixture: this pins the *specific patient-level*
+// extraction (which patient, expected vs. predicted, and the data-gap case)
+// that computeMetrics' aggregated confusion matrix intentionally discards.
+//
+// p1: careGap expected true, agent predicts false -> careGap false negative (miss).
+// p2: careGap expected false, agent predicts true -> careGap false positive.
+// p3: risk expected true, agent predicts 'moderate' (not high/critical) -> risk false negative.
+// p4: risk expected false, agent predicts 'critical' -> risk false positive.
+// p5: sdoh expected true, agent predicts no barrier -> sdoh disagreement.
+// p6: agrees everywhere on every dimension -> contributes nothing to any list.
+// p7: has a label row but NO findings entry at all -> reported once as a data gap,
+//     excluded from every other list (mirrors computeMetrics' "no run, no comparison" rule).
+const labels: LabelRow[] = [
+  {
+    patientId: 'p1',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: true, notes: 'p1 careGap notes' },
+    risk: { expectedHighRisk: null, notes: 'p1 risk unlabeled' },
+    sdoh: { expectedHasBarrier: null, notes: 'p1 sdoh unlabeled' },
+  },
+  {
+    patientId: 'p2',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: false, notes: 'p2 careGap notes' },
+    risk: { expectedHighRisk: null, notes: 'p2 risk unlabeled' },
+    sdoh: { expectedHasBarrier: null, notes: 'p2 sdoh unlabeled' },
+  },
+  {
+    patientId: 'p3',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: null, notes: 'p3 careGap unlabeled' },
+    risk: { expectedHighRisk: true, notes: 'p3 risk notes' },
+    sdoh: { expectedHasBarrier: null, notes: 'p3 sdoh unlabeled' },
+  },
+  {
+    patientId: 'p4',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: null, notes: 'p4 careGap unlabeled' },
+    risk: { expectedHighRisk: false, notes: 'p4 risk notes' },
+    sdoh: { expectedHasBarrier: null, notes: 'p4 sdoh unlabeled' },
+  },
+  {
+    patientId: 'p5',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: null, notes: 'p5 careGap unlabeled' },
+    risk: { expectedHighRisk: null, notes: 'p5 risk unlabeled' },
+    sdoh: { expectedHasBarrier: true, notes: 'p5 sdoh notes' },
+  },
+  {
+    patientId: 'p6',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: true, notes: 'p6 careGap notes' },
+    risk: { expectedHighRisk: true, notes: 'p6 risk notes' },
+    sdoh: { expectedHasBarrier: false, notes: 'p6 sdoh notes' },
+  },
+  {
+    patientId: 'p7',
+    source: 'dev',
+    clinicianOverride: null,
+    careGap: { expectedHasGap: true, notes: 'p7 careGap notes' },
+    risk: { expectedHighRisk: true, notes: 'p7 risk notes' },
+    sdoh: { expectedHasBarrier: true, notes: 'p7 sdoh notes' },
+  },
+];
+
+const findings: PatientFindings[] = [
+  {
+    patientId: 'p1',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'low' } },
+    sdoh: { findings: [] },
+  },
+  {
+    patientId: 'p2',
+    careGap: { findings: [{ gapType: 'HbA1c monitoring', description: 'x', urgency: 'high', fhirResourceId: 'Condition/2' }] },
+    risk: { findings: [], complete: { riskLevel: 'low' } },
+    sdoh: { findings: [] },
+  },
+  {
+    patientId: 'p3',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'moderate' } },
+    sdoh: { findings: [] },
+  },
+  {
+    patientId: 'p4',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'critical' } },
+    sdoh: { findings: [] },
+  },
+  {
+    patientId: 'p5',
+    careGap: { findings: [] },
+    risk: { findings: [], complete: { riskLevel: 'low' } },
+    sdoh: { findings: [] },
+  },
+  {
+    patientId: 'p6',
+    careGap: { findings: [{ gapType: 'BNP monitoring', description: 'x', urgency: 'high', fhirResourceId: 'Condition/6' }] },
+    risk: { findings: [], complete: { riskLevel: 'high' } },
+    sdoh: { findings: [] },
+  },
+  // p7 intentionally absent — the harness produced no findings for it this cycle.
+];
+
+describe('computeErrorAnalysis (S9 B1 — pure extraction, TDD)', () => {
+  it('extracts the specific care-gap false negative (p1) and false positive (p2)', () => {
+    const result = computeErrorAnalysis(labels, findings);
+    expect(result.careGap.falseNegatives).toEqual([
+      { patientId: 'p1', expected: true, predicted: false, labelNotes: 'p1 careGap notes' },
+    ]);
+    expect(result.careGap.falsePositives).toEqual([
+      { patientId: 'p2', expected: false, predicted: true, labelNotes: 'p2 careGap notes' },
+    ]);
+  });
+
+  it('extracts the specific risk false negative (p3) and false positive (p4)', () => {
+    const result = computeErrorAnalysis(labels, findings);
+    expect(result.risk.falseNegatives).toEqual([
+      { patientId: 'p3', expected: true, predictedRiskLevel: 'moderate', labelNotes: 'p3 risk notes' },
+    ]);
+    expect(result.risk.falsePositives).toEqual([
+      { patientId: 'p4', expected: false, predictedRiskLevel: 'critical', labelNotes: 'p4 risk notes' },
+    ]);
+  });
+
+  it('extracts the specific sdoh disagreement (p5)', () => {
+    const result = computeErrorAnalysis(labels, findings);
+    expect(result.sdoh.disagreements).toEqual([
+      { patientId: 'p5', expected: true, predicted: false, labelNotes: 'p5 sdoh notes' },
+    ]);
+  });
+
+  it('reports p7 once as a data gap and excludes it from every other list', () => {
+    const result = computeErrorAnalysis(labels, findings);
+    expect(result.dataGaps).toEqual([
+      { patientId: 'p7', reason: expect.any(String) },
+    ]);
+    const mentionsP7 = [
+      ...result.careGap.falseNegatives,
+      ...result.careGap.falsePositives,
+      ...result.risk.falseNegatives,
+      ...result.risk.falsePositives,
+      ...result.sdoh.disagreements,
+    ].some((entry) => entry.patientId === 'p7');
+    expect(mentionsP7).toBe(false);
+  });
+
+  it('contributes nothing to any list for a patient that agrees on every labeled dimension (p6)', () => {
+    const result = computeErrorAnalysis(labels, findings);
+    const mentionsP6 = [
+      ...result.careGap.falseNegatives,
+      ...result.careGap.falsePositives,
+      ...result.risk.falseNegatives,
+      ...result.risk.falsePositives,
+      ...result.sdoh.disagreements,
+      ...result.dataGaps,
+    ].some((entry) => entry.patientId === 'p6');
+    expect(mentionsP6).toBe(false);
+  });
+});

--- a/apps/api/src/eval/errorAnalysis.ts
+++ b/apps/api/src/eval/errorAnalysis.ts
@@ -1,4 +1,4 @@
-import { LabelRow, PatientFindings } from './computeMetrics';
+import { LabelRow, PatientFindings, HIGH_RISK_LEVELS } from './computeMetrics';
 
 /**
  * S9 B1 — pure extraction of the specific misses (false negatives) and false
@@ -18,13 +18,6 @@ import { LabelRow, PatientFindings } from './computeMetrics';
  * and not double-counted per dimension — "no run, no comparison," but the
  * report must still say why that patient contributed nothing.
  */
-
-// Duplicated from computeMetrics.ts rather than imported: that module
-// intentionally keeps this constant private (S9 A2 was reviewed/approved as-
-// is), and this is small enough (a two-value set, from riskAgent.ts's
-// REPORT_RISK_TOOL schema) that re-declaring it here is cheaper than widening
-// Phase A's export surface for a Phase B convenience.
-const HIGH_RISK_LEVELS = new Set(['high', 'critical']);
 
 export interface CareGapErrorEntry {
   patientId: string;

--- a/apps/api/src/eval/errorAnalysis.ts
+++ b/apps/api/src/eval/errorAnalysis.ts
@@ -1,0 +1,123 @@
+import { LabelRow, PatientFindings } from './computeMetrics';
+
+/**
+ * S9 B1 — pure extraction of the specific misses (false negatives) and false
+ * positives that computeMetrics' aggregated confusion matrix (Seam 4)
+ * intentionally collapses into a count. This is the data the eval report's
+ * mandatory error-analysis section needs (GD8, the P6 4->5 lever): which
+ * patient, what was expected, what the agent actually produced. Pure, no I/O
+ * — takes the same `LabelRow[]` / `PatientFindings[]` shapes as computeMetrics
+ * so both are driven off one shared harness pass over the same data.
+ *
+ * Domain rule: only a non-null label paired with a findings entry for that
+ * dimension can produce a hit/miss/false-positive — same exclusion rule
+ * computeMetrics documents (a `null` label is an honest "no ground truth"
+ * skip, not a fabricated guess). A patient whose label row has no findings
+ * entry AT ALL (the harness didn't run over them this cycle — e.g. a HAPI
+ * read failure) is reported exactly ONCE as a data gap, not silently dropped
+ * and not double-counted per dimension — "no run, no comparison," but the
+ * report must still say why that patient contributed nothing.
+ */
+
+// Duplicated from computeMetrics.ts rather than imported: that module
+// intentionally keeps this constant private (S9 A2 was reviewed/approved as-
+// is), and this is small enough (a two-value set, from riskAgent.ts's
+// REPORT_RISK_TOOL schema) that re-declaring it here is cheaper than widening
+// Phase A's export surface for a Phase B convenience.
+const HIGH_RISK_LEVELS = new Set(['high', 'critical']);
+
+export interface CareGapErrorEntry {
+  patientId: string;
+  expected: boolean;
+  predicted: boolean;
+  labelNotes: string;
+}
+
+export interface RiskErrorEntry {
+  patientId: string;
+  expected: boolean;
+  predictedRiskLevel: string;
+  labelNotes: string;
+}
+
+export interface SdohDisagreementEntry {
+  patientId: string;
+  expected: boolean;
+  predicted: boolean;
+  labelNotes: string;
+}
+
+export interface DataGapEntry {
+  patientId: string;
+  reason: string;
+}
+
+export interface ErrorAnalysis {
+  careGap: { falseNegatives: CareGapErrorEntry[]; falsePositives: CareGapErrorEntry[] };
+  risk: { falseNegatives: RiskErrorEntry[]; falsePositives: RiskErrorEntry[] };
+  sdoh: { disagreements: SdohDisagreementEntry[] };
+  dataGaps: DataGapEntry[];
+}
+
+/**
+ * S9 B1 (Seam-style pure helper, TDD). See module doc comment for the full
+ * contract.
+ */
+export function computeErrorAnalysis(labels: LabelRow[], findings: PatientFindings[]): ErrorAnalysis {
+  const findingsByPatientId = new Map(findings.map((f) => [f.patientId, f]));
+
+  const careGapFalseNegatives: CareGapErrorEntry[] = [];
+  const careGapFalsePositives: CareGapErrorEntry[] = [];
+  const riskFalseNegatives: RiskErrorEntry[] = [];
+  const riskFalsePositives: RiskErrorEntry[] = [];
+  const sdohDisagreements: SdohDisagreementEntry[] = [];
+  const dataGaps: DataGapEntry[] = [];
+
+  for (const label of labels) {
+    const patientFindings = findingsByPatientId.get(label.patientId);
+    if (!patientFindings) {
+      dataGaps.push({
+        patientId: label.patientId,
+        reason:
+          'No findings produced for this patient in this eval run (HAPI read failure, or a live-agent-run failure with no cache fallback) — excluded from every metric dimension, not silently dropped.',
+      });
+      continue;
+    }
+
+    if (label.careGap.expectedHasGap !== null && patientFindings.careGap) {
+      const expected = label.careGap.expectedHasGap;
+      const predicted = patientFindings.careGap.findings.length > 0;
+      if (expected && !predicted) {
+        careGapFalseNegatives.push({ patientId: label.patientId, expected, predicted, labelNotes: label.careGap.notes });
+      } else if (!expected && predicted) {
+        careGapFalsePositives.push({ patientId: label.patientId, expected, predicted, labelNotes: label.careGap.notes });
+      }
+    }
+
+    if (label.risk.expectedHighRisk !== null && patientFindings.risk) {
+      const expected = label.risk.expectedHighRisk;
+      const predictedRiskLevel = patientFindings.risk.complete.riskLevel;
+      const predictedHigh = HIGH_RISK_LEVELS.has(predictedRiskLevel);
+      if (expected && !predictedHigh) {
+        riskFalseNegatives.push({ patientId: label.patientId, expected, predictedRiskLevel, labelNotes: label.risk.notes });
+      } else if (!expected && predictedHigh) {
+        riskFalsePositives.push({ patientId: label.patientId, expected, predictedRiskLevel, labelNotes: label.risk.notes });
+      }
+    }
+
+    if (label.sdoh.expectedHasBarrier !== null && patientFindings.sdoh) {
+      const expected = label.sdoh.expectedHasBarrier;
+      const predicted = patientFindings.sdoh.findings.length > 0;
+      if (predicted !== expected) {
+        sdohDisagreements.push({ patientId: label.patientId, expected, predicted, labelNotes: label.sdoh.notes });
+      }
+    }
+  }
+
+  return {
+    careGap: { falseNegatives: careGapFalseNegatives, falsePositives: careGapFalsePositives },
+    risk: { falseNegatives: riskFalseNegatives, falsePositives: riskFalsePositives },
+    sdoh: { disagreements: sdohDisagreements },
+    dataGaps,
+  };
+}

--- a/apps/api/src/scripts/eval.ts
+++ b/apps/api/src/scripts/eval.ts
@@ -1,0 +1,421 @@
+/**
+ * S9 B1 — `npm run eval`. Loads the committed ground-truth label file
+ * (`data/eval/labels.json`), runs the four agents (preferring the S4
+ * `analysis_cache`, falling back to a live orchestrator run) over every
+ * labeled patient, scores the result against Phase A's pure `computeMetrics`
+ * (Seam 4) + the colocated `computeErrorAnalysis` helper, and writes:
+ *   - `docs/eval-report.md`   — human-readable methodology + error analysis.
+ *   - `docs/eval-report.json` — machine summary the S8 governance eval tile
+ *     reads from `governance/service.ts`'s `EVAL_REPORT_PATH` (must resolve
+ *     to the exact same file).
+ *
+ * Mirrors `scripts/import-fhir.ts`'s existing conventions for a `tsx`-run
+ * repo CLI script: no unit test for this glue itself (I/O-heavy — FHIR reads,
+ * filesystem writes), `main()` guarded by `require.main === module`, and its
+ * pieces exported for anything that wants to reuse them.
+ */
+import '../env'; // MUST load first — see index.ts: riskAgent.ts constructs `new OpenAI()` at import time.
+import fs from 'fs';
+import path from 'path';
+import { getDb } from '../db';
+import { FhirReadService, PatientBundle } from '../fhir/client';
+import { AuthTokenPayload } from '../auth/jwt';
+import { orchestrate } from '../agents/orchestrator';
+import { validateCitations, validateCitationList } from '../agents/citationValidator';
+import { readAnalysisCache } from '../db/analysisCache';
+import { computeMetrics, LabelRow, PatientFindings, MetricsReport, CareGapFinding, SdohFinding, ActionPlannerTask } from '../eval/computeMetrics';
+import { computeErrorAnalysis, ErrorAnalysis } from '../eval/errorAnalysis';
+
+const FHIR_BASE_URL = process.env.FHIR_BASE_URL ?? 'http://localhost:8080/fhir';
+
+// Resolved the same way governance/service.ts resolves EVAL_REPORT_PATH: from
+// `__dirname`, not `process.cwd()` (which varies with the invoking workspace
+// script). This script lives at the same depth (apps/api/src/scripts), so the
+// same 4-directories-up walk lands on the repo root either way.
+const LABELS_PATH = path.resolve(__dirname, '../../../../data/eval/labels.json');
+const REPORT_MD_PATH = path.resolve(__dirname, '../../../../docs/eval-report.md');
+// MUST equal governance/service.ts's EVAL_REPORT_PATH exactly — that's the
+// one hard, load-bearing contract this script has with the S8 eval tile.
+//
+// Ordering hazard: `routes/governance.test.ts`'s eval-endpoint suite writes
+// and `rmSync`s this exact path in its `afterEach` (pre-existing S8 test
+// behavior, not this script's doing). Running `apps/api`'s Jest suite after
+// `npm run eval` deletes this file. It is committed to the repo specifically
+// so that hazard is harmless locally (`git checkout -- docs/eval-report.json`
+// restores it) — re-run `npm run eval` (or check out the committed copy)
+// before relying on the file's presence if you've just run the full suite.
+const REPORT_JSON_PATH = path.resolve(__dirname, '../../../../docs/eval-report.json');
+
+// The eval harness runs as a script, not behind an HTTP login — there is no
+// real logged-in user to attribute FHIR reads/audit rows to. `director` is
+// the only role with 'clinical' scope AND is the role governance/service.ts
+// itself uses to gate the summary this script produces, so it's the natural
+// synthetic actor for both halves of this pipeline.
+const EVAL_ACTOR: AuthTokenPayload = { id: 'eval-harness', name: 'S9 Eval Harness', role: 'director' };
+
+interface LabelFile {
+  patients: LabelRow[];
+}
+
+function loadLabels(): LabelRow[] {
+  const raw = fs.readFileSync(LABELS_PATH, 'utf-8');
+  const parsed = JSON.parse(raw) as LabelFile;
+  return parsed.patients;
+}
+
+/**
+ * Assembles the same shape `computeMetrics` scores against (the
+ * post-`validateCitations` findings `AnalysisResultJson` surfaces to
+ * clinicians — see routes/analysis.ts) from a live orchestrator run, WITHOUT
+ * replaying that route's SSE/narration bookkeeping (narration text plays no
+ * role in scoring) and WITHOUT calling `replacePatientTasks` (which deletes +
+ * recreates real FHIR Tasks — a mutating side effect this read-only,
+ * repeatable-by-design harness deliberately avoids; `computeMetrics`'s
+ * Action Planner dimension is qualitative pass-through and only reads
+ * `id`/`title`/`description`/`priority`/`fhirResources`, none of which
+ * require a real HAPI-assigned Task id). A synthetic `eval-{patientId}-{n}`
+ * id stands in instead.
+ */
+async function runLive(bundle: PatientBundle, patientId: string): Promise<PatientFindings> {
+  let riskFindings: PatientFindings['risk'];
+  let careGapFindings: PatientFindings['careGap'];
+  let sdohFindings: PatientFindings['sdoh'];
+  let actionPlannerFindings: PatientFindings['actionPlanner'];
+
+  for await (const event of orchestrate(bundle)) {
+    if (event.type !== 'result') continue;
+
+    if (event.agentId === 'risk') {
+      const { valid } = validateCitations(event.output.flags, bundle.validIds);
+      riskFindings = { findings: valid, complete: { riskLevel: event.output.riskLevel } };
+    } else if (event.agentId === 'careGap') {
+      const { valid } = validateCitations(event.output.gaps, bundle.validIds);
+      careGapFindings = { findings: valid };
+    } else if (event.agentId === 'sdoh') {
+      const { valid } = validateCitations(event.output.barriers, bundle.validIds);
+      sdohFindings = { findings: valid };
+    } else {
+      const { valid } = validateCitationList(
+        event.output.tasks,
+        (task) => task.fhirResources,
+        (task, ids) => ({ ...task, fhirResources: ids }),
+        bundle.validIds
+      );
+      actionPlannerFindings = {
+        tasks: valid.map((task, i) => ({
+          id: `eval-${patientId}-${i}`,
+          title: task.title,
+          description: task.description,
+          priority: task.priority,
+          fhirResources: task.fhirResources,
+        })),
+      };
+    }
+  }
+
+  return { patientId, careGap: careGapFindings, risk: riskFindings, sdoh: sdohFindings, actionPlanner: actionPlannerFindings };
+}
+
+/** Maps a cached `AnalysisResultJson`-shaped row onto the `PatientFindings` shape `computeMetrics` scores against. */
+function fromCache(patientId: string, resultJson: unknown): PatientFindings {
+  const result = resultJson as {
+    careGap?: { findings: CareGapFinding[] };
+    risk?: { complete?: { riskLevel: string } };
+    sdoh?: { findings: SdohFinding[] };
+    actionPlanner?: { tasks: ActionPlannerTask[] };
+  };
+  return {
+    patientId,
+    careGap: result.careGap ? { findings: result.careGap.findings } : undefined,
+    risk: result.risk?.complete ? { findings: [], complete: { riskLevel: result.risk.complete.riskLevel } } : undefined,
+    sdoh: result.sdoh ? { findings: result.sdoh.findings } : undefined,
+    actionPlanner: result.actionPlanner ? { tasks: result.actionPlanner.tasks } : undefined,
+  };
+}
+
+export interface EvalRunResult {
+  findings: PatientFindings[];
+  /** Patients whose bundle/agent run failed outright this cycle (HAPI read error, etc.) — distinct from computeErrorAnalysis's dataGaps, which this feeds. */
+  failures: { patientId: string; error: string }[];
+  usedCache: string[];
+  usedLive: string[];
+}
+
+/**
+ * Runs the harness pass: for each labeled patient, prefer the S4
+ * `analysis_cache` row (fast, no HAPI/LLM round trip) and fall back to a live
+ * orchestrator run on a cache miss. A per-patient failure (HAPI read error,
+ * agent error) is caught, logged, and excluded from `findings` — never
+ * crashes the whole run — and recorded in `failures` so the report's
+ * error-analysis section can name it as a data-availability gap rather than
+ * silently dropping it.
+ */
+export async function runEval(labels: LabelRow[], fhirService: FhirReadService, db: ReturnType<typeof getDb>): Promise<EvalRunResult> {
+  const findings: PatientFindings[] = [];
+  const failures: { patientId: string; error: string }[] = [];
+  const usedCache: string[] = [];
+  const usedLive: string[] = [];
+
+  for (const label of labels) {
+    const patientId = label.patientId;
+    try {
+      const cached = readAnalysisCache(db, patientId);
+      if (cached) {
+        findings.push(fromCache(patientId, cached.resultJson));
+        usedCache.push(patientId);
+        continue;
+      }
+
+      const bundle = await fhirService.getPatientBundle(EVAL_ACTOR, patientId);
+      findings.push(await runLive(bundle, patientId));
+      usedLive.push(patientId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`eval: patient ${patientId} failed (excluded this run): ${message}`);
+      failures.push({ patientId, error: message });
+    }
+  }
+
+  return { findings, failures, usedCache, usedLive };
+}
+
+function formatPct(value: number | null): string {
+  return value === null ? 'n/a (denominator 0)' : `${(value * 100).toFixed(1)}%`;
+}
+
+function renderMarkdown(labels: LabelRow[], run: EvalRunResult, metrics: MetricsReport, errors: ErrorAnalysis): string {
+  const lines: string[] = [];
+  lines.push('# S9 Evaluation Report');
+  lines.push('');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push(
+    '**Status: DEV-LABELED BASELINE, NOT CLINICIAN-VALIDATED (GD8).** Ground truth is drawn from `data/eval/labels.json`, ' +
+      'whose `source` field is `"dev"` for every row today. Every row carries a `clinicianOverride` slot a clinician can ' +
+      'fill in later to upgrade this baseline without any code change. Do not present these numbers as clinician-reviewed.'
+  );
+  lines.push('');
+  lines.push('## Methodology');
+  lines.push('');
+  lines.push(
+    `- ${labels.length} labeled patients loaded from \`data/eval/labels.json\` (6 curated hero/panel patients + ` +
+      `10 deterministic \`pop-XXXX\` procedural patients — the plan's "~5 curated hero + ~10 Synthea" with the disclosed ` +
+      'S5 substitution: no real Synthea/Java in this repo).'
+  );
+  lines.push(
+    `- ${run.usedCache.length} patient(s) scored from the existing S4 \`analysis_cache\` (no live agent/LLM call this run): ` +
+      (run.usedCache.length > 0 ? run.usedCache.join(', ') : 'none') + '.'
+  );
+  lines.push(
+    `- ${run.usedLive.length} patient(s) scored from a live orchestrator run (cache miss): ` +
+      (run.usedLive.length > 0 ? run.usedLive.join(', ') : 'none') + '.'
+  );
+  lines.push(
+    `- ${run.failures.length} patient(s) failed outright this run (HAPI read error or agent error) and were excluded — ` +
+      'see Error Analysis below for detail on each.'
+  );
+  lines.push(
+    '- Findings are scored post-`validateCitations` (GD11) — the same citation-gated shape the product actually shows ' +
+      'clinicians, not raw/unvalidated agent output.'
+  );
+  lines.push(
+    '- The Action Planner\'s created tasks are read (via the citation gate) but never written to HAPI by this harness ' +
+      '(`replacePatientTasks` is deliberately not called) — a read-only, repeatable eval run should not mutate the ' +
+      'demo Task list on every invocation.'
+  );
+  lines.push('');
+
+  lines.push('## Per-agent metrics');
+  lines.push('');
+  lines.push('### Care Gap (binary: has a monitoring gap)');
+  lines.push('');
+  lines.push(`- Sensitivity: ${formatPct(metrics.careGap.sensitivity)}`);
+  lines.push(`- Specificity: ${formatPct(metrics.careGap.specificity)}`);
+  lines.push(`- PPV: ${formatPct(metrics.careGap.ppv)}`);
+  lines.push(
+    `- Confusion matrix (n=${metrics.careGap.labeledCount}): TP=${metrics.careGap.matrix.truePositive}, ` +
+      `TN=${metrics.careGap.matrix.trueNegative}, FP=${metrics.careGap.matrix.falsePositive}, FN=${metrics.careGap.matrix.falseNegative}`
+  );
+  lines.push('');
+  lines.push('### Risk (binary: high/critical readmission risk)');
+  lines.push('');
+  lines.push(`- Sensitivity: ${formatPct(metrics.risk.sensitivity)}`);
+  lines.push(`- Specificity: ${formatPct(metrics.risk.specificity)}`);
+  lines.push(`- PPV: ${formatPct(metrics.risk.ppv)}`);
+  lines.push(
+    `- Confusion matrix (n=${metrics.risk.labeledCount}): TP=${metrics.risk.matrix.truePositive}, ` +
+      `TN=${metrics.risk.matrix.trueNegative}, FP=${metrics.risk.matrix.falsePositive}, FN=${metrics.risk.matrix.falseNegative}`
+  );
+  lines.push('');
+  lines.push('### SDOH (agreement rate: has an actionable barrier)');
+  lines.push('');
+  lines.push(
+    `- Agreement rate: ${formatPct(metrics.sdoh.agreementRate)} (${metrics.sdoh.agreements}/${metrics.sdoh.total}). ` +
+      'Read alongside the SDOH limitation noted in `data/eval/labels.json` `_meta.limitations` — only one positive ' +
+      'example (maria-chen) exists in this dataset, so this rate is easy to game with an always-negative predictor.'
+  );
+  lines.push('');
+  lines.push('### Action Planner (qualitative — synthesis, not classification)');
+  lines.push('');
+  if (metrics.actionPlanner.notes.length === 0) {
+    lines.push('No patients produced an Action Planner result this run.');
+  } else {
+    for (const note of metrics.actionPlanner.notes) {
+      lines.push(`- **${note.patientId}**: ${note.taskCount} task(s) created — ${note.taskTitles.join('; ') || '(none)'}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Error analysis (mandatory — GD8, the P6 4→5 lever)');
+  lines.push('');
+  lines.push('### Care Gap misses (false negatives — agent said no gap, label says there is one)');
+  lines.push('');
+  if (errors.careGap.falseNegatives.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const e of errors.careGap.falseNegatives) {
+      lines.push(`- **${e.patientId}**: expected a gap, agent found none. Label rationale: ${e.labelNotes}`);
+    }
+  }
+  lines.push('');
+  lines.push('### Care Gap false positives (agent flagged a gap, label says there isn\'t one)');
+  lines.push('');
+  if (errors.careGap.falsePositives.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const e of errors.careGap.falsePositives) {
+      lines.push(`- **${e.patientId}**: agent flagged a gap, label expects none. Label rationale: ${e.labelNotes}`);
+    }
+  }
+  lines.push('');
+  lines.push('### Risk misses (false negatives — agent under-called risk)');
+  lines.push('');
+  if (errors.risk.falseNegatives.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const e of errors.risk.falseNegatives) {
+      lines.push(`- **${e.patientId}**: expected high/critical risk, agent predicted "${e.predictedRiskLevel}". Label rationale: ${e.labelNotes}`);
+    }
+  }
+  lines.push('');
+  lines.push('### Risk false positives (agent over-called risk)');
+  lines.push('');
+  if (errors.risk.falsePositives.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const e of errors.risk.falsePositives) {
+      lines.push(`- **${e.patientId}**: expected low/moderate risk, agent predicted "${e.predictedRiskLevel}". Label rationale: ${e.labelNotes}`);
+    }
+  }
+  lines.push('');
+  lines.push('### SDOH disagreements');
+  lines.push('');
+  if (errors.sdoh.disagreements.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const e of errors.sdoh.disagreements) {
+      lines.push(
+        `- **${e.patientId}**: expected ${e.expected ? 'a barrier' : 'no barrier'}, agent predicted ${e.predicted ? 'a barrier' : 'no barrier'}. Label rationale: ${e.labelNotes}`
+      );
+    }
+  }
+  lines.push('');
+  lines.push('### Data-availability gaps (patient excluded from every dimension this run)');
+  lines.push('');
+  if (errors.dataGaps.length === 0 && run.failures.length === 0) {
+    lines.push('None.');
+  } else {
+    for (const gap of errors.dataGaps) {
+      const failure = run.failures.find((f) => f.patientId === gap.patientId);
+      lines.push(`- **${gap.patientId}**: ${gap.reason}${failure ? ` (error: ${failure.error})` : ''}`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * JSON-summary shaping — deliberately kept as plain object construction
+ * (not a separately-tested pure function): it's a direct field-for-field
+ * re-projection of `metrics`/`errors`/`run` with no branching logic of its
+ * own to pin, so a unit test here would just re-assert the object literal.
+ * `headline` is the one field `governance/service.ts`'s `getEvalSummary`
+ * special-cases for prose rendering; everything else is free-form.
+ */
+function buildJsonSummary(labels: LabelRow[], run: EvalRunResult, metrics: MetricsReport, errors: ErrorAnalysis) {
+  const totalErrors =
+    errors.careGap.falseNegatives.length +
+    errors.careGap.falsePositives.length +
+    errors.risk.falseNegatives.length +
+    errors.risk.falsePositives.length +
+    errors.sdoh.disagreements.length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    clinicianStatus: 'DEV-LABELED BASELINE, NOT CLINICIAN-VALIDATED (GD8)',
+    headline: `Eval run over ${labels.length} labeled patients (${run.failures.length} failed): Care Gap sensitivity ${formatPct(
+      metrics.careGap.sensitivity
+    )}, Risk sensitivity ${formatPct(metrics.risk.sensitivity)}, SDOH agreement ${formatPct(
+      metrics.sdoh.agreementRate
+    )}, ${totalErrors} labeled disagreement(s) found.`,
+    patientCount: labels.length,
+    usedCacheCount: run.usedCache.length,
+    usedLiveCount: run.usedLive.length,
+    failedPatientIds: run.failures.map((f) => f.patientId),
+    careGap: {
+      sensitivity: metrics.careGap.sensitivity,
+      specificity: metrics.careGap.specificity,
+      ppv: metrics.careGap.ppv,
+      matrix: metrics.careGap.matrix,
+      labeledCount: metrics.careGap.labeledCount,
+    },
+    risk: {
+      sensitivity: metrics.risk.sensitivity,
+      specificity: metrics.risk.specificity,
+      ppv: metrics.risk.ppv,
+      matrix: metrics.risk.matrix,
+      labeledCount: metrics.risk.labeledCount,
+    },
+    sdoh: {
+      agreementRate: metrics.sdoh.agreementRate,
+      agreements: metrics.sdoh.agreements,
+      total: metrics.sdoh.total,
+    },
+    actionPlanner: {
+      notes: metrics.actionPlanner.notes,
+    },
+    errorAnalysis: errors,
+  };
+}
+
+async function main(): Promise<void> {
+  const labels = loadLabels();
+  const db = getDb();
+  const fhirService = new FhirReadService(db, FHIR_BASE_URL);
+
+  console.log(`eval: scoring ${labels.length} labeled patients against ${FHIR_BASE_URL}...`);
+  const run = await runEval(labels, fhirService, db);
+
+  const metrics = computeMetrics(labels, run.findings);
+  const errors = computeErrorAnalysis(labels, run.findings);
+
+  const markdown = renderMarkdown(labels, run, metrics, errors);
+  fs.writeFileSync(REPORT_MD_PATH, markdown, 'utf-8');
+  console.log(`eval: wrote ${REPORT_MD_PATH}`);
+
+  const jsonSummary = buildJsonSummary(labels, run, metrics, errors);
+  fs.writeFileSync(REPORT_JSON_PATH, JSON.stringify(jsonSummary, null, 2), 'utf-8');
+  console.log(`eval: wrote ${REPORT_JSON_PATH}`);
+
+  console.log(`eval: done. ${run.findings.length}/${labels.length} patients scored, ${run.failures.length} failed.`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { loadLabels, renderMarkdown, buildJsonSummary, LABELS_PATH, REPORT_MD_PATH, REPORT_JSON_PATH };

--- a/data/eval/labels.json
+++ b/data/eval/labels.json
@@ -1,0 +1,355 @@
+{
+  "_meta": {
+    "description": "S9 A1 — committed ground-truth label file for the eval harness (Phase B: `npm run eval`). Covers all 6 curated hero/panel patients (`ALL_PATIENTS`, apps/api/src/fhir-data/seed-patients.ts) plus the first 10 deterministic procedural patients (`pop-0001`..`pop-0010`, apps/api/src/fhir-data/population.ts's `generatePopulation()`) — the plan's '~5 curated hero + ~10 Synthea' with the disclosed S5 substitution (no real Synthea/Java in this repo; `pop-XXXX` deterministic patients stand in, precedent: docs/plans/caresync-ai/verification-s5.md).",
+    "clinicianStatus": "DEV-LABELED BASELINE, NOT CLINICIAN-VALIDATED (GD8). Every row's `source` is \"dev\" and every row carries a `clinicianOverride` slot (currently `null`) that a clinician can fill in later to upgrade a row without any code change (GD8's 4->5 lever). Do not present these labels as clinician-reviewed.",
+    "labelingRules": {
+      "careGap": "expectedHasGap is derived ONLY from Observation-type coverage for the two (three, counting CKD) conditions that already have an established LOINC convention elsewhere in this codebase: diabetes (E11.9) needs an HbA1c Observation (LOINC 4548-4, as seeded for maria-chen); CHF (I50.9) needs a BNP Observation (LOINC 30934-4, as seeded for maria-chen); CKD (N18.3) needs an eGFR Observation (LOINC 62238-1, also seeded for maria-chen, general renal marker). A patient with one of these conditions and NO matching Observation on file is labeled true (a real, defensible monitoring gap: the record shows the test was never done). A patient with the condition AND a matching Observation on file is labeled false. Conditions with no established Observation/LOINC convention anywhere in this codebase (depression F33.1, COPD J44.9, HTN I10, acute hip fracture S72.001A) are left UNLABELED (expectedHasGap: null) rather than guessing — see `clinicianStatus`/GD8 for the override path.",
+      "risk": "expectedHighRisk is true iff the patient's own seed/generator riskScore (SeedPatient.riskScore for curated patients; the deterministic riskScoreFor() output for procedural patients — both documented, pre-existing values, not invented for this label file) is >= 75, the same CRITICAL_RISK_THRESHOLD population.ts already uses for its 'critical zone'. Ground truth is compared against whether the Risk agent's `riskLevel` output is 'high' or 'critical'.",
+      "sdoh": "expectedHasBarrier is true only for patients with a seeded AHC-HRSN screening (`sdohPositive` in seed-patients.ts) — the only SDOH-relevant evidence this dataset provides anywhere. Only maria-chen has one. Every other patient (panel and procedural) is labeled false: the SDOH agent's own prompt scopes it to the AHC-HRSN screening + demographics + observations, and none of those other patients have any AHC-HRSN screening or SDOH-relevant observation for it to find.",
+      "actionPlanner": "No per-patient ground truth (Action Planner is qualitative synthesis, not classification, per the plan). `computeMetrics` passes through each patient's created-task data unscored for Phase B's report to narrate."
+    },
+    "limitations": [
+      "Care Gap ground truth is skewed positive (10 true / 1 false / 5 unlabeled across the 16 rows) because population.ts never generates baseline preventive-care Observations for any procedural patient — there is only one real negative example (maria-chen, who has both her HbA1c and BNP on file). Specificity for Care Gap in this baseline rests on a single data point and should be read as illustrative, not statistically robust, until clinician-reviewed rows or richer procedural Observation data exist.",
+      "SDOH ground truth has only one positive example (maria-chen) for the same reason (no other patient has any seeded AHC-HRSN data) — the agreement rate is easy to game with an agent that always predicts 'no barrier' and should be read alongside the error-analysis section Phase B's report is required to include, not in isolation."
+    ]
+  },
+  "patients": [
+    {
+      "patientId": "maria-chen",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": false,
+        "notes": "Diabetes (E11.9) has Observation/maria-chen-hba1c on file; CHF (I50.9) has Observation/maria-chen-bnp on file — both the conditions this dataset's Observation coding actually covers are monitored. Her depression (F33.1) has no corresponding Observation type established anywhere in this codebase, so that dimension is intentionally left out of this boolean rather than guessed at."
+      },
+      "risk": {
+        "expectedHighRisk": true,
+        "seedRiskScore": 87,
+        "notes": "Seed riskScore 87 >= 75 (CRITICAL_RISK_THRESHOLD). Independently plausible from her raw data: CHF admission 48h ago, BNP 340 (elevated), HbA1c 8.9% (poorly controlled), eGFR 52 (reduced), K+ 3.4 (low) — a clinically high-risk 30-day-readmission profile."
+      },
+      "sdoh": {
+        "expectedHasBarrier": true,
+        "expectedDomains": ["housing", "food"],
+        "notes": "Observation/maria-chen-sdoh: AHC-HRSN screening positive for housing instability and food insecurity."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "james-okafor",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": null,
+        "notes": "COPD (J44.9) only. No spirometry/pulmonary-function Observation convention exists anywhere in this codebase to judge monitoring adequacy against — left unlabeled rather than guessed."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 62,
+        "notes": "Seed riskScore 62 < 75."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "No seeded AHC-HRSN screening or any other SDOH-relevant evidence for this patient."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "linda-torres",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "CKD stage 3 (N18.3) with zero Observations on file, including no eGFR (LOINC 62238-1, the exact renal-function marker this codebase already seeds for maria-chen) — a real, defensible monitoring gap for a CKD patient."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 71,
+        "notes": "Seed riskScore 71 < 75 (just under threshold)."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "No seeded AHC-HRSN screening or any other SDOH-relevant evidence for this patient."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "robert-kim",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": null,
+        "notes": "Acute hip fracture (S72.001A) — not a recurring chronic-monitoring condition with an established Observation convention in this codebase (no bone-density/DEXA marker seeded anywhere). Left unlabeled rather than guessed."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 45,
+        "notes": "Seed riskScore 45 < 75."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "No seeded AHC-HRSN screening or any other SDOH-relevant evidence for this patient."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "angela-diaz",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": null,
+        "notes": "HTN (I10) and depression (F33.1) — neither has an established Observation/LOINC monitoring convention anywhere in this codebase (no blood-pressure or PHQ-9-equivalent Observation is ever seeded). Left unlabeled rather than guessed."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 58,
+        "notes": "Seed riskScore 58 < 75."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "No seeded AHC-HRSN screening or any other SDOH-relevant evidence for this patient."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "samuel-wright",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "CHF (I50.9) with zero Observations on file, including no BNP (LOINC 30934-4) — same monitoring-gap logic as maria-chen's CHF dimension, but unmonitored here."
+      },
+      "risk": {
+        "expectedHighRisk": true,
+        "seedRiskScore": 79,
+        "notes": "Seed riskScore 79 >= 75."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "No seeded AHC-HRSN screening or any other SDOH-relevant evidence for this patient."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0001",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['diabetes'] (generatePopulation() never seeds any Observation) — no HbA1c on file for a diabetes diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 38,
+        "notes": "Generator riskScore 38 < 75 (inspected directly via generatePopulation()[0])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0002",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['chf'] — no BNP on file for a CHF diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 38,
+        "notes": "Generator riskScore 38 < 75 (inspected directly via generatePopulation()[1])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0003",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": null,
+        "notes": "Procedural patient, condition mix ['depression'] — depression has no established Observation/LOINC monitoring convention anywhere in this codebase. Left unlabeled rather than guessed."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 32,
+        "notes": "Generator riskScore 32 < 75 (inspected directly via generatePopulation()[2])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0004",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['diabetes','chf'] — no HbA1c and no BNP on file for either diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 66,
+        "notes": "Generator riskScore 66 < 75 (inspected directly via generatePopulation()[3])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0005",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['diabetes','depression'] — no HbA1c on file for the diabetes diagnosis (depression itself is left out of the rule, but diabetes alone is enough to label this true)."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 50,
+        "notes": "Generator riskScore 50 < 75 (inspected directly via generatePopulation()[4])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0006",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['chf','depression'] — no BNP on file for the CHF diagnosis (depression itself is left out of the rule, but CHF alone is enough to label this true)."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 46,
+        "notes": "Generator riskScore 46 < 75 (inspected directly via generatePopulation()[5])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0007",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['diabetes','chf','depression'] — no HbA1c and no BNP on file for either classifiable diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": true,
+        "seedRiskScore": 92,
+        "notes": "Generator riskScore 92 >= 75 (inspected directly via generatePopulation()[6]) — full three-condition comorbidity plus a recent (60h) discharge."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0008",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['diabetes'] — no HbA1c on file for the diabetes diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 32,
+        "notes": "Generator riskScore 32 < 75 (inspected directly via generatePopulation()[7])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0009",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": true,
+        "notes": "Procedural patient, condition mix ['chf'] — no BNP on file for the CHF diagnosis."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 48,
+        "notes": "Generator riskScore 48 < 75 (inspected directly via generatePopulation()[8])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    },
+    {
+      "patientId": "pop-0010",
+      "source": "dev",
+      "clinicianOverride": null,
+      "careGap": {
+        "expectedHasGap": null,
+        "notes": "Procedural patient, condition mix ['depression'] — depression has no established Observation/LOINC monitoring convention anywhere in this codebase. Left unlabeled rather than guessed."
+      },
+      "risk": {
+        "expectedHighRisk": false,
+        "seedRiskScore": 28,
+        "notes": "Generator riskScore 28 < 75 (inspected directly via generatePopulation()[9])."
+      },
+      "sdoh": {
+        "expectedHasBarrier": false,
+        "notes": "Procedural patients never receive a seeded AHC-HRSN screening or any other SDOH-relevant evidence."
+      },
+      "actionPlanner": {
+        "notes": "Qualitative only — see Phase B report."
+      }
+    }
+  ]
+}

--- a/docs/eval-report.json
+++ b/docs/eval-report.json
@@ -1,0 +1,296 @@
+{
+  "generatedAt": "2026-07-06T15:59:33.945Z",
+  "clinicianStatus": "DEV-LABELED BASELINE, NOT CLINICIAN-VALIDATED (GD8)",
+  "headline": "Eval run over 16 labeled patients (0 failed): Care Gap sensitivity 100.0%, Risk sensitivity 100.0%, SDOH agreement 100.0%, 10 labeled disagreement(s) found.",
+  "patientCount": 16,
+  "usedCacheCount": 1,
+  "usedLiveCount": 15,
+  "failedPatientIds": [],
+  "careGap": {
+    "sensitivity": 1,
+    "specificity": 0,
+    "ppv": 0.9090909090909091,
+    "matrix": {
+      "truePositive": 10,
+      "trueNegative": 0,
+      "falsePositive": 1,
+      "falseNegative": 0
+    },
+    "labeledCount": 11
+  },
+  "risk": {
+    "sensitivity": 1,
+    "specificity": 0.3076923076923077,
+    "ppv": 0.25,
+    "matrix": {
+      "truePositive": 3,
+      "trueNegative": 4,
+      "falsePositive": 9,
+      "falseNegative": 0
+    },
+    "labeledCount": 16
+  },
+  "sdoh": {
+    "agreementRate": 1,
+    "agreements": 16,
+    "total": 16
+  },
+  "actionPlanner": {
+    "notes": [
+      {
+        "patientId": "maria-chen",
+        "taskCount": 9,
+        "taskTitles": [
+          "Complete urgent post-discharge medication reconciliation",
+          "Schedule heart-failure post-discharge follow-up by 2026-07-11",
+          "Escalate abnormal potassium and kidney function for clinical review",
+          "Activate housing navigator referral",
+          "Connect patient to food assistance and heart-failure/diabetes-appropriate nutrition support",
+          "Address poor diabetes control and kidney-protection monitoring gaps",
+          "Coordinate depression symptom monitoring and support",
+          "Close routine diabetes screening gaps: retinal and foot exams",
+          "Plan age-appropriate preventive screenings"
+        ]
+      },
+      {
+        "patientId": "james-okafor",
+        "taskCount": 5,
+        "taskTitles": [
+          "Complete urgent pulmonology follow-up",
+          "Coordinate COPD post-discharge management visit",
+          "Obtain smoking status and tobacco-use assessment",
+          "Arrange COPD monitoring with spirometry or pulmonary function testing",
+          "Address colorectal cancer screening gap"
+        ]
+      },
+      {
+        "patientId": "linda-torres",
+        "taskCount": 3,
+        "taskTitles": [
+          "Complete repeat BMP for CKD post-discharge monitoring",
+          "Arrange CKD urine albumin/protein assessment",
+          "Obtain and document blood pressure measurement"
+        ]
+      },
+      {
+        "patientId": "robert-kim",
+        "taskCount": 4,
+        "taskTitles": [
+          "Coordinate high-risk post-hip-fracture transition plan",
+          "Arrange fall-risk assessment and mitigation",
+          "Initiate osteoporosis evaluation and secondary fracture prevention",
+          "Order or verify bone-health laboratory assessment"
+        ]
+      },
+      {
+        "patientId": "angela-diaz",
+        "taskCount": 6,
+        "taskTitles": [
+          "Complete post-discharge blood pressure recheck",
+          "Assess depression symptoms and adherence barriers",
+          "Coordinate high-risk readmission follow-up plan",
+          "Verify or schedule colorectal cancer screening",
+          "Verify or schedule breast cancer screening",
+          "Verify or schedule cervical cancer screening"
+        ]
+      },
+      {
+        "patientId": "samuel-wright",
+        "taskCount": 5,
+        "taskTitles": [
+          "Arrange urgent heart-failure follow-up / care-management contact",
+          "Close overdue daily weight monitoring gap",
+          "Reinforce sodium-restricted diet education",
+          "Obtain current heart-failure vital signs",
+          "Coordinate renal function and electrolyte labs"
+        ]
+      },
+      {
+        "patientId": "pop-0001",
+        "taskCount": 6,
+        "taskTitles": [
+          "Complete post-discharge transition-of-care outreach",
+          "Arrange prompt diabetes follow-up visit",
+          "Order overdue diabetes laboratory monitoring: HbA1c and kidney function",
+          "Order urine albumin-creatinine ratio screening",
+          "Schedule diabetic retinal eye exam",
+          "Complete comprehensive diabetic foot exam"
+        ]
+      },
+      {
+        "patientId": "pop-0002",
+        "taskCount": 4,
+        "taskTitles": [
+          "Arrange urgent post-discharge heart-failure follow-up",
+          "Obtain renal function and electrolyte labs for heart-failure management",
+          "Coordinate LVEF/echocardiography assessment",
+          "Initiate colorectal cancer screening outreach"
+        ]
+      },
+      {
+        "patientId": "pop-0003",
+        "taskCount": 6,
+        "taskTitles": [
+          "Complete urgent post-discharge behavioral health outreach and follow-up",
+          "Administer depression severity monitoring",
+          "Review readmission risk and update care plan",
+          "Arrange cervical cancer screening",
+          "Arrange breast cancer screening",
+          "Arrange colorectal cancer screening"
+        ]
+      },
+      {
+        "patientId": "pop-0004",
+        "taskCount": 4,
+        "taskTitles": [
+          "Arrange urgent post-discharge follow-up",
+          "Assess heart failure status and safety labs",
+          "Order overdue HbA1c monitoring",
+          "Order diabetic kidney disease screening"
+        ]
+      },
+      {
+        "patientId": "pop-0005",
+        "taskCount": 4,
+        "taskTitles": [
+          "Arrange urgent post-discharge follow-up visit",
+          "Obtain overdue HbA1c for diabetes monitoring",
+          "Complete diabetic kidney-health monitoring",
+          "Screen and monitor depressive symptoms"
+        ]
+      },
+      {
+        "patientId": "pop-0006",
+        "taskCount": 5,
+        "taskTitles": [
+          "Schedule urgent heart-failure post-discharge follow-up",
+          "Obtain post-discharge renal function and electrolyte labs",
+          "Set up heart-failure home vital sign and weight monitoring",
+          "Perform medication reconciliation and heart-failure self-management teach-back",
+          "Screen and reassess depression symptoms"
+        ]
+      },
+      {
+        "patientId": "pop-0007",
+        "taskCount": 6,
+        "taskTitles": [
+          "Complete urgent post-discharge outreach and follow-up scheduling",
+          "Arrange heart failure renal function and electrolyte monitoring",
+          "Arrange diabetes HbA1c and kidney monitoring",
+          "Coordinate medication reconciliation with heart failure and diabetes focus",
+          "Order diabetes lipid monitoring",
+          "Complete depression symptom severity screening"
+        ]
+      },
+      {
+        "patientId": "pop-0008",
+        "taskCount": 5,
+        "taskTitles": [
+          "Schedule urgent post-discharge follow-up",
+          "Order HbA1c testing for diabetes monitoring",
+          "Order diabetic kidney health screening",
+          "Schedule diabetic retinal eye exam",
+          "Complete diabetic foot exam"
+        ]
+      },
+      {
+        "patientId": "pop-0009",
+        "taskCount": 6,
+        "taskTitles": [
+          "Schedule 7-day heart-failure post-discharge follow-up",
+          "Obtain urgent heart-failure monitoring data",
+          "Perform post-discharge outreach and home self-management check",
+          "Address missing breast cancer screening",
+          "Address missing colorectal cancer screening",
+          "Address missing cervical cancer screening"
+        ]
+      },
+      {
+        "patientId": "pop-0010",
+        "taskCount": 4,
+        "taskTitles": [
+          "Complete suicide-risk reassessment and safety check",
+          "Schedule overdue post-discharge behavioral-health follow-up",
+          "Initiate standardized depression symptom monitoring",
+          "Create readmission-prevention follow-up plan"
+        ]
+      }
+    ]
+  },
+  "errorAnalysis": {
+    "careGap": {
+      "falseNegatives": [],
+      "falsePositives": [
+        {
+          "patientId": "maria-chen",
+          "expected": false,
+          "predicted": true,
+          "labelNotes": "Diabetes (E11.9) has Observation/maria-chen-hba1c on file; CHF (I50.9) has Observation/maria-chen-bnp on file — both the conditions this dataset's Observation coding actually covers are monitored. Her depression (F33.1) has no corresponding Observation type established anywhere in this codebase, so that dimension is intentionally left out of this boolean rather than guessed at."
+        }
+      ]
+    },
+    "risk": {
+      "falseNegatives": [],
+      "falsePositives": [
+        {
+          "patientId": "james-okafor",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Seed riskScore 62 < 75."
+        },
+        {
+          "patientId": "linda-torres",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Seed riskScore 71 < 75 (just under threshold)."
+        },
+        {
+          "patientId": "robert-kim",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Seed riskScore 45 < 75."
+        },
+        {
+          "patientId": "angela-diaz",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Seed riskScore 58 < 75."
+        },
+        {
+          "patientId": "pop-0002",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Generator riskScore 38 < 75 (inspected directly via generatePopulation()[1])."
+        },
+        {
+          "patientId": "pop-0004",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Generator riskScore 66 < 75 (inspected directly via generatePopulation()[3])."
+        },
+        {
+          "patientId": "pop-0005",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Generator riskScore 50 < 75 (inspected directly via generatePopulation()[4])."
+        },
+        {
+          "patientId": "pop-0006",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Generator riskScore 46 < 75 (inspected directly via generatePopulation()[5])."
+        },
+        {
+          "patientId": "pop-0009",
+          "expected": false,
+          "predictedRiskLevel": "high",
+          "labelNotes": "Generator riskScore 48 < 75 (inspected directly via generatePopulation()[8])."
+        }
+      ]
+    },
+    "sdoh": {
+      "disagreements": []
+    },
+    "dataGaps": []
+  }
+}

--- a/docs/eval-report.md
+++ b/docs/eval-report.md
@@ -1,0 +1,87 @@
+# S9 Evaluation Report
+
+Generated: 2026-07-06T15:59:33.941Z
+
+**Status: DEV-LABELED BASELINE, NOT CLINICIAN-VALIDATED (GD8).** Ground truth is drawn from `data/eval/labels.json`, whose `source` field is `"dev"` for every row today. Every row carries a `clinicianOverride` slot a clinician can fill in later to upgrade this baseline without any code change. Do not present these numbers as clinician-reviewed.
+
+## Methodology
+
+- 16 labeled patients loaded from `data/eval/labels.json` (6 curated hero/panel patients + 10 deterministic `pop-XXXX` procedural patients — the plan's "~5 curated hero + ~10 Synthea" with the disclosed S5 substitution: no real Synthea/Java in this repo).
+- 1 patient(s) scored from the existing S4 `analysis_cache` (no live agent/LLM call this run): maria-chen.
+- 15 patient(s) scored from a live orchestrator run (cache miss): james-okafor, linda-torres, robert-kim, angela-diaz, samuel-wright, pop-0001, pop-0002, pop-0003, pop-0004, pop-0005, pop-0006, pop-0007, pop-0008, pop-0009, pop-0010.
+- 0 patient(s) failed outright this run (HAPI read error or agent error) and were excluded — see Error Analysis below for detail on each.
+- Findings are scored post-`validateCitations` (GD11) — the same citation-gated shape the product actually shows clinicians, not raw/unvalidated agent output.
+- The Action Planner's created tasks are read (via the citation gate) but never written to HAPI by this harness (`replacePatientTasks` is deliberately not called) — a read-only, repeatable eval run should not mutate the demo Task list on every invocation.
+
+## Per-agent metrics
+
+### Care Gap (binary: has a monitoring gap)
+
+- Sensitivity: 100.0%
+- Specificity: 0.0%
+- PPV: 90.9%
+- Confusion matrix (n=11): TP=10, TN=0, FP=1, FN=0
+
+### Risk (binary: high/critical readmission risk)
+
+- Sensitivity: 100.0%
+- Specificity: 30.8%
+- PPV: 25.0%
+- Confusion matrix (n=16): TP=3, TN=4, FP=9, FN=0
+
+### SDOH (agreement rate: has an actionable barrier)
+
+- Agreement rate: 100.0% (16/16). Read alongside the SDOH limitation noted in `data/eval/labels.json` `_meta.limitations` — only one positive example (maria-chen) exists in this dataset, so this rate is easy to game with an always-negative predictor.
+
+### Action Planner (qualitative — synthesis, not classification)
+
+- **maria-chen**: 9 task(s) created — Complete urgent post-discharge medication reconciliation; Schedule heart-failure post-discharge follow-up by 2026-07-11; Escalate abnormal potassium and kidney function for clinical review; Activate housing navigator referral; Connect patient to food assistance and heart-failure/diabetes-appropriate nutrition support; Address poor diabetes control and kidney-protection monitoring gaps; Coordinate depression symptom monitoring and support; Close routine diabetes screening gaps: retinal and foot exams; Plan age-appropriate preventive screenings
+- **james-okafor**: 5 task(s) created — Complete urgent pulmonology follow-up; Coordinate COPD post-discharge management visit; Obtain smoking status and tobacco-use assessment; Arrange COPD monitoring with spirometry or pulmonary function testing; Address colorectal cancer screening gap
+- **linda-torres**: 3 task(s) created — Complete repeat BMP for CKD post-discharge monitoring; Arrange CKD urine albumin/protein assessment; Obtain and document blood pressure measurement
+- **robert-kim**: 4 task(s) created — Coordinate high-risk post-hip-fracture transition plan; Arrange fall-risk assessment and mitigation; Initiate osteoporosis evaluation and secondary fracture prevention; Order or verify bone-health laboratory assessment
+- **angela-diaz**: 6 task(s) created — Complete post-discharge blood pressure recheck; Assess depression symptoms and adherence barriers; Coordinate high-risk readmission follow-up plan; Verify or schedule colorectal cancer screening; Verify or schedule breast cancer screening; Verify or schedule cervical cancer screening
+- **samuel-wright**: 5 task(s) created — Arrange urgent heart-failure follow-up / care-management contact; Close overdue daily weight monitoring gap; Reinforce sodium-restricted diet education; Obtain current heart-failure vital signs; Coordinate renal function and electrolyte labs
+- **pop-0001**: 6 task(s) created — Complete post-discharge transition-of-care outreach; Arrange prompt diabetes follow-up visit; Order overdue diabetes laboratory monitoring: HbA1c and kidney function; Order urine albumin-creatinine ratio screening; Schedule diabetic retinal eye exam; Complete comprehensive diabetic foot exam
+- **pop-0002**: 4 task(s) created — Arrange urgent post-discharge heart-failure follow-up; Obtain renal function and electrolyte labs for heart-failure management; Coordinate LVEF/echocardiography assessment; Initiate colorectal cancer screening outreach
+- **pop-0003**: 6 task(s) created — Complete urgent post-discharge behavioral health outreach and follow-up; Administer depression severity monitoring; Review readmission risk and update care plan; Arrange cervical cancer screening; Arrange breast cancer screening; Arrange colorectal cancer screening
+- **pop-0004**: 4 task(s) created — Arrange urgent post-discharge follow-up; Assess heart failure status and safety labs; Order overdue HbA1c monitoring; Order diabetic kidney disease screening
+- **pop-0005**: 4 task(s) created — Arrange urgent post-discharge follow-up visit; Obtain overdue HbA1c for diabetes monitoring; Complete diabetic kidney-health monitoring; Screen and monitor depressive symptoms
+- **pop-0006**: 5 task(s) created — Schedule urgent heart-failure post-discharge follow-up; Obtain post-discharge renal function and electrolyte labs; Set up heart-failure home vital sign and weight monitoring; Perform medication reconciliation and heart-failure self-management teach-back; Screen and reassess depression symptoms
+- **pop-0007**: 6 task(s) created — Complete urgent post-discharge outreach and follow-up scheduling; Arrange heart failure renal function and electrolyte monitoring; Arrange diabetes HbA1c and kidney monitoring; Coordinate medication reconciliation with heart failure and diabetes focus; Order diabetes lipid monitoring; Complete depression symptom severity screening
+- **pop-0008**: 5 task(s) created — Schedule urgent post-discharge follow-up; Order HbA1c testing for diabetes monitoring; Order diabetic kidney health screening; Schedule diabetic retinal eye exam; Complete diabetic foot exam
+- **pop-0009**: 6 task(s) created — Schedule 7-day heart-failure post-discharge follow-up; Obtain urgent heart-failure monitoring data; Perform post-discharge outreach and home self-management check; Address missing breast cancer screening; Address missing colorectal cancer screening; Address missing cervical cancer screening
+- **pop-0010**: 4 task(s) created — Complete suicide-risk reassessment and safety check; Schedule overdue post-discharge behavioral-health follow-up; Initiate standardized depression symptom monitoring; Create readmission-prevention follow-up plan
+
+## Error analysis (mandatory — GD8, the P6 4→5 lever)
+
+### Care Gap misses (false negatives — agent said no gap, label says there is one)
+
+None.
+
+### Care Gap false positives (agent flagged a gap, label says there isn't one)
+
+- **maria-chen**: agent flagged a gap, label expects none. Label rationale: Diabetes (E11.9) has Observation/maria-chen-hba1c on file; CHF (I50.9) has Observation/maria-chen-bnp on file — both the conditions this dataset's Observation coding actually covers are monitored. Her depression (F33.1) has no corresponding Observation type established anywhere in this codebase, so that dimension is intentionally left out of this boolean rather than guessed at.
+
+### Risk misses (false negatives — agent under-called risk)
+
+None.
+
+### Risk false positives (agent over-called risk)
+
+- **james-okafor**: expected low/moderate risk, agent predicted "high". Label rationale: Seed riskScore 62 < 75.
+- **linda-torres**: expected low/moderate risk, agent predicted "high". Label rationale: Seed riskScore 71 < 75 (just under threshold).
+- **robert-kim**: expected low/moderate risk, agent predicted "high". Label rationale: Seed riskScore 45 < 75.
+- **angela-diaz**: expected low/moderate risk, agent predicted "high". Label rationale: Seed riskScore 58 < 75.
+- **pop-0002**: expected low/moderate risk, agent predicted "high". Label rationale: Generator riskScore 38 < 75 (inspected directly via generatePopulation()[1]).
+- **pop-0004**: expected low/moderate risk, agent predicted "high". Label rationale: Generator riskScore 66 < 75 (inspected directly via generatePopulation()[3]).
+- **pop-0005**: expected low/moderate risk, agent predicted "high". Label rationale: Generator riskScore 50 < 75 (inspected directly via generatePopulation()[4]).
+- **pop-0006**: expected low/moderate risk, agent predicted "high". Label rationale: Generator riskScore 46 < 75 (inspected directly via generatePopulation()[5]).
+- **pop-0009**: expected low/moderate risk, agent predicted "high". Label rationale: Generator riskScore 48 < 75 (inspected directly via generatePopulation()[8]).
+
+### SDOH disagreements
+
+None.
+
+### Data-availability gaps (patient excluded from every dimension this run)
+
+None.

--- a/docs/plans/caresync-ai/implementation-plan.md
+++ b/docs/plans/caresync-ai/implementation-plan.md
@@ -535,32 +535,33 @@ All reads over existing SQLite + HAPI — no new writable state. Parity/confiden
 
 ### Phase A — Labels + metric core (test-first)
 
-- [ ] **A1. Committed label file.** `data/eval/labels.json` — ground truth for ~5 hero + ~10 Synthea, rows structured so a clinician can review/override the Synthea rows later (GD8).
+- [x] **A1. Committed label file.** `data/eval/labels.json` — ground truth for ~5 hero + ~10 Synthea, rows structured so a clinician can review/override the Synthea rows later (GD8).
   - *Domain rule:* label file holds ground truth with clinician-overridable rows (S9 acceptance).
+  - *Deviation note:* no real Synthea data exists in this codebase (a disclosed S5 substitution) — the "~10 Synthea" rows are `pop-0001..pop-0010` from `population.ts`'s deterministic generator; "~5 curated hero" is all 6 of `ALL_PATIENTS` (Maria Chen + 5 panel patients).
 
-- [ ] **A2. Metric computation — Seam 4 (pure, TDD).** `computeMetrics(labels, findings)` → sensitivity/specificity/PPV (Care Gap + Risk), agreement (SDOH), qualitative notes (Action Planner).
+- [x] **A2. Metric computation — Seam 4 (pure, TDD).** `computeMetrics(labels, findings)` → sensitivity/specificity/PPV (Care Gap + Risk), agreement (SDOH), qualitative notes (Action Planner).
   - *Domain rule:* per-agent metrics per GD8; Action Planner is qualitative (synthesis, not classification).
   - *Test (Seam 4):* against a fixed label + findings fixture, the metrics match a known expected output exactly.
 
 ### Phase B — Harness + report
 
-- [ ] **B1. `npm run eval` harness.** Load labeled patients from HAPI → run the four agents (live or cached) over each → `computeMetrics` → write `docs/eval-report.md` (**with a mandatory error-analysis section**: misses + false positives) + a JSON summary.
+- [x] **B1. `npm run eval` harness.** Load labeled patients from HAPI → run the four agents (live or cached) over each → `computeMetrics` → write `docs/eval-report.md` (**with a mandatory error-analysis section**: misses + false positives) + a JSON summary.
   - *Domain rule:* report includes explicit error analysis (S9 acceptance, GD8 — this is the 4→5 lever); JSON summary consumed by the S8 tile.
   - *Verify:* `npm run eval` produces the report + JSON; the S8 eval tile renders the headline from it.
 
 ### Phase C — Verification
-- [ ] **C1.** Seam 4 unit test green; one full `npm run eval` run committed as evidence (labeled *dev-labeled baseline*).
-- [ ] **C2.** The S8 governance eval tile consumes the produced JSON (cross-slice check).
+- [x] **C1.** Seam 4 unit test green; one full `npm run eval` run committed as evidence (labeled *dev-labeled baseline*).
+- [x] **C2.** The S8 governance eval tile consumes the produced JSON (cross-slice check).
 
 ### Rollback / safety
 Read-only over HAPI + labels; outputs are generated files (`docs/eval-report.md` + JSON), regenerable. Ships explicitly as a **dev-labeled ~P6 4** baseline; clinician override of the Synthea rows upgrades to 5 with no code change (GD8).
 
 ### Definition of done (S9) — maps to `issues.md`
-- Committed label file with clinician-overridable rows (A1).
-- `npm run eval` runs agents over all labeled patients + computes per-agent metrics (A2, B1).
-- Report includes an explicit error-analysis section (B1).
-- JSON summary produced + consumed by the S8 tile (B1, C2).
-- Metric computation tested against a fixed fixture with known output — Seam 4 (A2).
+- [x] Committed label file with clinician-overridable rows (A1).
+- [x] `npm run eval` runs agents over all labeled patients + computes per-agent metrics (A2, B1).
+- [x] Report includes an explicit error-analysis section (B1).
+- [x] JSON summary produced + consumed by the S8 tile (B1, C2).
+- [x] Metric computation tested against a fixed fixture with known output — Seam 4 (A2).
 
 ---
 

--- a/docs/plans/caresync-ai/issues.md
+++ b/docs/plans/caresync-ai/issues.md
@@ -213,11 +213,11 @@ JSON summary that feeds the S8 governance tile. Ships as an honest dev-labeled b
 (~P6 4) with the slot to upgrade to clinician-validated (P6 5).
 
 ### Acceptance criteria
-- [ ] A committed label file holds ground truth with rows structured for later clinician override.
-- [ ] `npm run eval` runs agents over all labeled patients and computes the metrics per agent.
-- [ ] The report includes an explicit error-analysis section.
-- [ ] A JSON summary is produced and consumed by the S8 governance tile.
-- [ ] Harness metric computation is tested against a fixed label fixture with known expected output (Seam 4).
+- [x] A committed label file holds ground truth with rows structured for later clinician override.
+- [x] `npm run eval` runs agents over all labeled patients and computes the metrics per agent.
+- [x] The report includes an explicit error-analysis section.
+- [x] A JSON summary is produced and consumed by the S8 governance tile.
+- [x] Harness metric computation is tested against a fixed label fixture with known expected output (Seam 4).
 
 ### Blocked by
 - S3

--- a/docs/plans/caresync-ai/review-s9.md
+++ b/docs/plans/caresync-ai/review-s9.md
@@ -1,0 +1,96 @@
+# Code Review — CareSync AI, S9 (Evaluation harness + report)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S9 · **Date:** 2026-07-06
+> **Diff:** `main` (`d219b9c`) `...HEAD` (`73abcce` at review time), 4 commits.
+> **Spec sources:** `docs/plans/caresync-ai/issues.md` S9, `implementation-plan.md` Iteration 9,
+> `verification-s9.md`. This repo has no `CODING_STANDARDS.md`/`CONTRIBUTING.md` and `CLAUDE.md`'s
+> "Code style" section is an empty placeholder — the Standards axis instead measured the diff against
+> the closest established sibling modules (`agents/citationValidator.ts`'s pure-Seam-module convention,
+> `governance/service.ts`'s exported-pure-helper convention) plus the fixed Fowler smell baseline.
+> Prior review preserved at `review-s8.md`.
+
+## Standards
+
+**Convention match: strong.** `apps/api/src/eval/computeMetrics.ts` and `errorAnalysis.ts` follow the
+established Seam-module pattern exactly: pure functions, no I/O, otherwise-private helpers exported
+specifically for direct unit testing (`tallyConfusionMatrix`, `classificationMetricsFromMatrix`), the
+same "Domain rule:"/rationale-comment density as `citationValidator.ts` and `governance/service.ts`,
+and the same "`null`-not-fabricated" honesty convention for unlabeled/undecidable cases. `scripts/eval.ts`
+mirrors `scripts/import-fhir.ts`'s CLI-script wiring (`tsx`, workspace `package.json` script → root
+passthrough) precisely.
+
+**Hard finding, fixed during this review:** `errorAnalysis.ts` duplicated `computeMetrics.ts`'s
+`HIGH_RISK_LEVELS` constant verbatim, justified by an in-code comment claiming the constant was
+"intentionally private." It wasn't private for a documented reason — it was the same domain decision
+(what counts as "high risk") needed in two files, i.e. Fowler's Duplicated Code. Left as-is, a future
+change to the risk-level threshold (e.g. adding `'severe'`) could silently drift between the two files
+with nothing enforcing consistency. **Fixed:** exported `HIGH_RISK_LEVELS` from `computeMetrics.ts`,
+`errorAnalysis.ts` now imports it. Re-verified: `tsc --noEmit` clean, 187/187 API tests pass
+(commit `73abcce`).
+
+**Baseline smells found, left as-is (judgement calls, not fixed):**
+- **Duplicated Code (structural, not the constant above)** — `computeMetrics.ts` and `errorAnalysis.ts`
+  each independently loop over `labels` and re-derive the same three per-dimension predicates
+  (`careGap.findings.length > 0`, `HIGH_RISK_LEVELS.has(riskLevel)`, `sdoh.findings.length > 0`) in their
+  own pass, despite `errorAnalysis.ts`'s own doc comment describing them as "driven off one shared
+  harness pass." A `classifyPatient(label, findings)` helper returning `{expected, predicted}` per
+  dimension would remove the twin loops. Not fixed in this pass: it's a real but moderate-size
+  refactor (touches both modules' internals, both already reviewed/approved once), and the two
+  modules' outputs are independently tested against fixed fixtures, so the duplication is a
+  maintainability cost, not a correctness risk today. Worth revisiting if a fifth eval dimension is
+  ever added.
+- **Long Function / low cohesion (borderline Divergent Change)** — `scripts/eval.ts` (421 lines) mixes
+  label loading, live-agent orchestration, cache deserialization, the run loop, ~150 lines of Markdown
+  rendering, and JSON-summary shaping in one file. Each concern would change for a different reason
+  (label schema vs. report wording vs. orchestrator wiring). Mitigated by extensive comments and by
+  following `import-fhir.ts`'s existing single-script-file convention (no sibling CLI script in this
+  repo splits its rendering/glue into separate files either) — left as a documented judgement call
+  rather than a unilateral refactor that would make this script inconsistent with its nearest sibling.
+- **Data Clumps (mild)** — `CareGapErrorEntry`/`SdohDisagreementEntry` in `errorAnalysis.ts` share an
+  identical `{patientId, expected, predicted, labelNotes}` shape (only `RiskErrorEntry` differs). Minor;
+  each type is domain-named per-dimension, which the baseline itself treats as mitigating.
+
+Not flagged, considered and dismissed: `scripts/eval.ts`'s cache-vs-live branching isn't a Repeated
+Switch risk (it's one two-way branch, not a recurring cascade); the generated `docs/eval-report.md`/
+`.json` being committed alongside source is a deliberate plan requirement (C1), not accidental
+build-artifact drift.
+
+## Spec
+
+**Verdict: clean.** No missing/partial requirements, no scope creep, no wrong-implementation findings
+survive verification.
+
+- **All five S9 acceptance bullets (`issues.md`) are genuinely implemented, not stubbed** — the
+  committed label file has real `source: "dev"` / `clinicianOverride: null` rows (not just claimed);
+  `npm run eval` was run for real (16/16 patients, 0 failures, live FHIR + live LLM calls, not mocked);
+  `computeMetrics` is genuinely pure (no `fs`/`path`/network imports, verified by reading the source);
+  the JSON summary lands at `governance/service.ts`'s exact `EVAL_REPORT_PATH` and was proven consumed
+  live via a direct `getEvalSummary()` call against the real DB and the real generated file.
+- **"~5 curated hero + ~10 Synthea" (plan line 528/538)**: the label file uses all 6 `ALL_PATIENTS` +
+  `pop-0001..pop-0010`. The "Synthea" substitution (no real Synthea data exists in this repo) is
+  disclosed explicitly in three places — the plan's own A1 deviation note, `labels.json`'s `_meta`
+  block, and the rendered report's Methodology section — matching the precedent S5 already set, not a
+  silently reinterpreted requirement.
+- **"Mandatory error-analysis section" (plan line 547)**: substantive, not a stub — `docs/eval-report.md`
+  names 9 specific risk false positives and 1 care-gap false positive by patient ID with per-patient
+  rationale.
+- **A real, honest eval finding surfaced by the harness itself** (not a code defect): Risk specificity
+  is low (30.8%, 9 false positives). This is disclosed in `labels.json`'s `_meta.limitations` and the
+  report, consistent with GD8's "honest dev-labeled baseline" framing rather than smoothed over.
+- **No scope creep** — the diff is additive only (new `eval/` module, `scripts/eval.ts`, label file,
+  generated reports, two `package.json` script entries); `governance/service.ts` and all other S8 files
+  are untouched, honoring the cross-slice contract read-only from S9's side.
+
+No discrepancies found between `verification-s9.md`'s narrative and the actual diff contents.
+
+## Summary
+
+**Standards:** 1 hard finding (fixed in this review — duplicated `HIGH_RISK_LEVELS` constant), 3
+baseline smells (judgement calls, left as-is — a structural duplicated-loop pattern across the two eval
+modules, `scripts/eval.ts`'s multi-concern length, a mild data-clump). Worst issue: the duplicated
+constant, now fixed.
+**Spec:** 0 findings. Worst issue: none.
+
+## Next step
+
+`finishing-a-development-branch` — push, open the PR against `main`, and merge.

--- a/docs/plans/caresync-ai/verification-s9.md
+++ b/docs/plans/caresync-ai/verification-s9.md
@@ -1,0 +1,167 @@
+# Verification — CareSync AI, S9 (Evaluation harness + report)
+
+> **PLAN_ID:** `caresync-ai` · **Slice:** S9 · **Date:** 2026-07-06
+> **Stage:** Phase 5 (`verification-before-completion`), run on `feature/caresync-s9-eval-harness`
+> (base `d219b9c` = `main`, tip `206d924`, 2 commits: `da61229` Phase A — labels + Seam 4
+> `computeMetrics`, `206d924` Phase B — `npm run eval` harness + report). Read
+> `docs/plans/caresync-ai/implementation-plan.md` Iteration 9 and `docs/plans/caresync-ai/issues.md`
+> S9 for the plan this verifies against — not re-derived here. Built via `subagent-driven-development`:
+> one implementer subagent per phase, one independent reviewer subagent per phase (not the implementer
+> grading its own work, each reviewer re-ran commands and cross-checked source data itself rather than
+> trusting the implementer's report), both re-confirmed again in this consolidated pass.
+
+## 0. Pre-implementation plan correction (before any code was written)
+
+A research pass against the live codebase, run before dispatching either phase, found the plan's prose
+described the codebase slightly differently than it actually is. None of these blocked implementation;
+all were folded into the implementer prompts up front rather than discovered mid-build:
+
+- **No real Synthea data exists in this repo.** The plan's "~10 Synthea patients" is `pop-0001..pop-0010`
+  from `population.ts`'s deterministic PRNG generator — the same disclosed substitution S5 already made.
+- **No `HERO_PATIENT_IDS` constant exists.** "~5 curated hero" patients are all 6 of `ALL_PATIENTS`
+  (Maria Chen + 5 panel patients) from `seed-patients.ts`.
+- **No standalone "run agents + validate + cache" function exists** — only the raw `orchestrate()`
+  generator and route-embedded `validateCitations` glue in `routes/analysis.ts`. The harness replicates
+  that glue rather than scoring unvalidated raw agent output.
+- **S8's eval-tile coupling is looser than the plan's prose implies** — only the file path
+  `docs/eval-report.json` and an optional top-level `headline: string` are load-bearing (confirmed by
+  reading `Governance.tsx`'s `EvalSummaryContent` directly); no other field names matter to the consumer.
+
+## 1. Fresh command evidence (this session, 2026-07-06)
+
+Re-run fresh in this final consolidated pass, on top of each phase's independent reviewer's own run:
+
+| Command | Result |
+|---|---|
+| `cd apps/api && npx jest --runInBand` | **31 suites / 187 tests passed** |
+| `cd apps/api && npx tsc --noEmit` | exit 0 |
+| `npm run eval` (repo root, live FHIR + live LLM calls) | **16/16 labeled patients scored, 0 failed** |
+| `docs/eval-report.json` / `.md` valid, headline present | confirmed by direct read |
+
+No `apps/web`/E2E re-run — S9 makes no frontend or screen-behavior change (backend script + committed
+data file only), so `frontend-e2e-verification` does not apply per this repo's own trigger rule.
+
+**Real, reproduced ordering hazard**: running the full `apps/api` Jest suite deletes
+`docs/eval-report.json` via a pre-existing S8 test's `afterEach` (`routes/governance.test.ts`, not S9's
+code). Observed directly in this pass: ran the suite, confirmed `docs/eval-report.json` was gone
+(`git status` showed it deleted), then ran `git checkout -- docs/eval-report.json` and confirmed it was
+restored byte-for-byte because the file is now committed (`206d924`). This is the reason C1's "commit
+the eval run as evidence" requirement is load-bearing and not just a nice-to-have — an uncommitted
+artifact would have been unrecoverably lost by the next `npm run test:api`.
+
+## 2. Definition-of-done check (S9 acceptance, `issues.md`)
+
+All 5 acceptance bullets confirmed against the actual code and this session's fresh evidence:
+
+1. **Committed label file with clinician-overridable rows** — `data/eval/labels.json`, 16 rows (6
+   curated + `pop-0001..pop-0010`), each with `source: "dev"` and a `clinicianOverride: null` slot, plus
+   a `_meta` block stating the GD8 dev-labeled/not-clinician-validated disclosure. Independently
+   cross-checked by the Phase A reviewer against the real seed data and a live `generatePopulation()`
+   run — no fabricated labels found; unlabeled dimensions (`null`) used where the codebase has no
+   established observation/LOINC convention (e.g. COPD, HTN, depression) rather than guessed values.
+2. **`npm run eval` runs agents over all labeled patients, computes per-agent metrics** —
+   `apps/api/src/scripts/eval.ts`, wired as `npm run eval` (root) → `--workspace apps/api`. Cache-first
+   (`readAnalysisCache`) with a live `orchestrate()` + `validateCitations` fallback, matching the
+   product's own validated-findings shape (`AnalysisResultJson`), not raw/unvalidated agent output. This
+   session's live run: 16/16 scored (1 from cache, 15 live), 0 failures.
+3. **Report includes an explicit error-analysis section** — `docs/eval-report.md` names specific
+   patient IDs with predicted-vs-labeled detail (e.g. 9 named risk false positives, 1 named care-gap
+   false positive), extracted by a new pure `computeErrorAnalysis` (Seam-style, TDD, colocated test).
+   The Phase B reviewer cross-checked 6 of the reported false positives directly against
+   `data/eval/labels.json`'s stored fields and confirmed each matches verbatim — not fabricated.
+4. **JSON summary produced and consumed by the S8 governance tile** — `docs/eval-report.json` written
+   to the exact `EVAL_REPORT_PATH` `governance/service.ts` reads (`path.resolve(__dirname,
+   '../../../../docs/eval-report.json')`, same 4-directory-up walk from the same source depth,
+   confirmed identical in both files). The Phase B reviewer proved consumption live — not by
+   description — by calling `getEvalSummary()` directly against the real DB and the real generated file
+   and observing `{available: true, summary: {headline: "...", ...}}` returned.
+5. **Metric computation tested against a fixed fixture with known output (Seam 4)** —
+   `apps/api/src/eval/computeMetrics.ts` + `computeMetrics.test.ts`: a hand-built 5-patient fixture,
+   `toEqual` exact-value assertions, hand-recomputed by the Phase A reviewer for every dimension
+   (careGap 0.5/0.5/0.5, risk 1/1/1, SDOH agreement 0.75) and matched exactly. `computeErrorAnalysis`
+   (Phase B's new pure module) has its own separate 5-case fixture, independently hand-recomputed for
+   4 of 5 cases by the Phase B reviewer with the same result.
+
+No drift between what's claimed done and what the code does.
+
+## 3. Spec-drift check (issues.md / implementation-plan.md vs. code)
+
+Real plan-vs-reality mismatches, all caught during pre-implementation research or by the reviewers
+(§0 above), resolved honestly rather than silently:
+
+- **"~10 Synthea patients" corrected to `pop-0001..pop-0010`** (no real Synthea data in this repo —
+  same disclosed S5 substitution). Documented in the plan's A1 deviation note (see the checked-off
+  implementation-plan.md).
+- **"reuses the S3 orchestrator" is true but incomplete** — the harness had to additionally replicate
+  `routes/analysis.ts`'s citation-validation glue itself, since no reusable "run + validate" function
+  existed to import. This is a pragmatic, ponytail-consistent duplication of ~20-30 lines, not a new
+  agent path, and was a deliberate choice flagged up front rather than discovered as a surprise gap.
+- **The plan's B1 line ("a JSON summary") undersold how loose S8's actual consumer contract is** —
+  confirmed only `docs/eval-report.json`'s path and an optional `headline: string` matter; the rest of
+  the JSON's shape was designed freely by the Phase B implementer (per-agent metrics, error analysis,
+  patient counts) with no risk of breaking S8's already-shipped tile.
+- **New, real finding from the eval run itself (not a code defect)**: Risk agent specificity came out
+  low (30.8%, 9 of 16 patients flagged "high" risk against the seeded/generated `riskScore < 75`
+  threshold). This is exactly the kind of result S9 exists to surface honestly — recorded in
+  `docs/eval-report.md`'s error-analysis section as a real finding about the live agent's behavior, not
+  smoothed over or hidden.
+
+Other checks:
+- **No new persisted state** — `apps/api/src/db/index.ts`'s `migrate()` unchanged. S9 adds a read-only
+  script + two generated/committed files; no schema change.
+- **`implementation-plan.md` Iteration 9's checkboxes** — A1-A2, B1, C1-C2, and the Definition-of-done
+  bullets are now all `[x]` (this session), matching the actual committed state.
+
+## 4. Review notes
+
+Both phases were built by an implementer subagent under an explicit TDD requirement (failing test
+first, confirmed red for the right reason, then green), and **each phase's implementer report was
+independently re-verified by a separate reviewer subagent** — not the same agent grading its own work.
+Both reviewers went beyond re-running tests: the Phase A reviewer independently ran
+`generatePopulation()` itself and cross-checked all 16 label rows against real source data (seed
+patients' actual embedded FHIR resources and the generator's live output), and the Phase B reviewer
+independently called `getEvalSummary()` against the real DB and cross-checked 6 reported error-analysis
+entries against the label file's raw fields. Both phases returned **APPROVE**.
+
+The Phase B reviewer surfaced one real, non-blocking gap (the eval-report.json test-cleanup deletion
+hazard, §1) that the implementer had itself already flagged as a to-decide item rather than hidden —
+resolved in this consolidated pass by (a) committing the generated artifacts as required by C1 and
+(b) adding an explicit doc-comment in `eval.ts` recording the hazard and its `git checkout` mitigation.
+
+No `NEEDS_CONTEXT` escalations were raised by either implementer.
+
+## 5. Domain-term documentation check
+
+New domain concepts introduced by S9 — the `apps/api/src/eval/` module (`computeMetrics`,
+`computeErrorAnalysis`, Seam 4), the `data/eval/labels.json` dev-labeled/clinician-override row
+convention (GD8), and the `docs/eval-report.json`/`.md` generated-and-committed-evidence pair — are
+documented inline via doc comments at their introduction point (`computeMetrics.ts`,
+`errorAnalysis.ts`, `eval.ts`, `labels.json`'s `_meta` block), consistent with the "Domain rule:"
+convention established since S2. `docs/agents/domain.md` and `docs/agents/issue-tracker.md` still don't
+exist — the same pre-existing, deferred gap noted in every prior slice's verification (S5, S7, S8),
+unchanged by S9.
+
+## 6. Evidence-boundary labeling (CLAUDE.md)
+
+Per CLAUDE.md's evidence-boundaries rule: all evidence in this document is **local mock / packaged
+script strength** — Jest suites and one real `npm run eval` run against the local Docker HAPI container
+and live LLM calls from this development machine. This proves the harness actually reads real patient
+bundles, actually invokes the real four-agent pipeline with real citation validation, and actually
+produces a file the real S8 endpoint reads — but it is **not** target-environment, client-accepted, or
+production-hardware evidence, and the labels themselves are explicitly **dev-labeled, not
+clinician-validated** (GD8) — the eval's own headline numbers (e.g. 100% Care Gap/Risk/SDOH figures
+against dev labels) should not be read as a clinically validated accuracy claim.
+
+## 7. Gate outcome
+
+**PASS.** All fresh command evidence is green (§1). Definition-of-done (§2) and spec-drift (§3) checks
+found several real plan-prose-vs-reality corrections (Synthea substitution, no reusable validated-run
+function, looser-than-stated S8 coupling) and one real operational hazard (test-cleanup deleting the
+committed evidence file) — all resolved honestly and documented rather than papered over. No
+product-behavior defects remain open, and no fabricated labels or fabricated report numbers were found
+anywhere in the shipped label file or generated report (independently cross-checked against source data
+by both phase reviewers, not just internally consistency-checked).
+
+## Next step
+
+`code-review`, covering the full branch diff since `main` along the Standards and Spec axes.

--- a/docs/superpowers/specs/feature-caresync-s9-eval-harness/2026-07-06-changelog.md
+++ b/docs/superpowers/specs/feature-caresync-s9-eval-harness/2026-07-06-changelog.md
@@ -1,0 +1,129 @@
+# Changelog: S9 — Evaluation harness + report
+
+**Type:** Feature
+
+**Branch:** `feature/caresync-s9-eval-harness` (branched off `main` at the S8 merge, `d219b9c`)
+
+**Date:** 2026-07-06
+
+## Summary
+
+Delivers the P6 lever (GD8): a runnable `npm run eval` that scores the four agents (Care Gap, Risk,
+SDOH, Action Planner) against a committed, dev-labeled ground-truth set — 6 curated patients + 10
+deterministic procedural patients — and produces a Markdown methodology report with a mandatory
+error-analysis section, plus a JSON summary consumed by S8's previously-placeholder governance eval
+tile. Ships explicitly as a **dev-labeled ~P6 4 baseline** (not clinician-validated), with a
+clinician-override slot on every label row that upgrades it to 5 with no code change.
+
+## Changes Made
+
+### Backend — Ground-truth labels + Seam 4 pure metrics (A1, A2)
+
+- **Before:** No eval labels, no metric-computation module.
+- **After:** `data/eval/labels.json` — 16 rows (`ALL_PATIENTS` from `seed-patients.ts` + `pop-0001`
+  through `pop-0010` from `population.ts`'s deterministic generator), each carrying `source: "dev"`
+  and a `clinicianOverride: null` slot, plus a `_meta` block disclosing the GD8 dev-labeled status and
+  known limitations. **Plan-vs-reality correction**: the plan's "~10 Synthea patients" doesn't exist in
+  this codebase — there is no real Synthea import, only `population.ts`'s procedural generator — so the
+  10 rows are `pop-XXXX` ids, the same disclosed substitution S5 already established. Ground truth for
+  Care Gap is restricted to conditions with an established Observation/LOINC convention already present
+  elsewhere in the codebase (diabetes→HbA1c, CHF→BNP, CKD→eGFR); everything else is honestly left `null`
+  ("no confident ground truth") rather than guessed.
+  `apps/api/src/eval/computeMetrics.ts` — pure `computeMetrics(labels, findings)` → sensitivity/
+  specificity/PPV for Care Gap + Risk, an agreement rate for SDOH, qualitative notes for Action Planner.
+  TDD: hand-built 5-patient fixture, exact-value assertions, independently hand-recomputed twice
+  (once per phase reviewer) with matching results.
+- **Files changed:** `data/eval/labels.json`, `apps/api/src/eval/{computeMetrics,computeMetrics.test}.ts`.
+
+### Backend — `npm run eval` harness + report (B1)
+
+- **Before:** No way to run the four-agent pipeline over the labeled set and no eval report existed.
+- **After:** `apps/api/src/scripts/eval.ts` (wired as `npm run eval`, mirroring `import-fhir.ts`'s
+  `tsx`-script convention): for each labeled patient, reads `analysis_cache` if present, else runs the
+  S3 `orchestrate()` generator live and applies the existing `validateCitations` (Seam 2) to assemble
+  the same validated `AnalysisResultJson`-shaped findings the product actually shows users — not raw,
+  unvalidated agent output. Scores via `computeMetrics` + a new pure `computeErrorAnalysis` (TDD,
+  `apps/api/src/eval/errorAnalysis.ts`) extracting the specific per-patient misses/false-positives the
+  aggregated confusion matrix collapses into counts. Writes `docs/eval-report.md` (methodology + a
+  **mandatory error-analysis section** naming specific patients and predicted-vs-labeled detail — the
+  plan's explicit 4→5 lever) and `docs/eval-report.json` at the exact `EVAL_REPORT_PATH`
+  `governance/service.ts` already reads (S8 shipped this endpoint with a documented placeholder path;
+  S9 is the first slice to actually populate it). Per-patient failures are caught and reported as data
+  gaps rather than crashing the run.
+- **Files changed:** `apps/api/src/scripts/eval.ts`, `apps/api/src/eval/{errorAnalysis,errorAnalysis.test}.ts`,
+  `apps/api/package.json` (`eval` script), root `package.json` (`eval` script passthrough).
+
+### Verification — Real live run + cross-slice proof
+
+- `npm run eval` was run for real against the local Docker HAPI stack with live LLM calls (not mocked):
+  16/16 labeled patients scored, 0 failures. Result: Care Gap sensitivity 100%, Risk sensitivity 100%,
+  SDOH agreement 100%, but Risk specificity only 30.8% (9 false positives) and Care Gap specificity 0%
+  off a single negative example — an honest finding about the live agents' behavior against a dev-labeled
+  baseline, disclosed in the report itself, not smoothed over.
+- Cross-slice consumption (S9→S8) proved live, not by description: `getEvalSummary()` called directly
+  against the real DB with the real generated file on disk returned `{available: true, summary: {...}}`.
+- **Real, reproduced operational hazard**: a pre-existing S8 test (`routes/governance.test.ts`) deletes
+  `docs/eval-report.json` in its `afterEach` as part of its own fixture cleanup. Running the full
+  `apps/api` Jest suite after `npm run eval` destroys the JSON evidence file. Mitigated by committing the
+  generated artifacts (satisfying the plan's own C1 requirement) so `git checkout -- docs/eval-report.json`
+  recovers it, and documented inline in `eval.ts`'s doc comment.
+
+## Files Modified
+
+| File | Change Description |
+|------|---------------------|
+| `data/eval/labels.json` | New — dev-labeled ground truth, 16 patients, clinician-override slots |
+| `apps/api/src/eval/computeMetrics.ts` | New — Seam 4 pure metric computation |
+| `apps/api/src/eval/computeMetrics.test.ts` | New — fixed-fixture TDD tests |
+| `apps/api/src/eval/errorAnalysis.ts` | New — pure per-patient miss/false-positive extraction |
+| `apps/api/src/eval/errorAnalysis.test.ts` | New — fixed-fixture TDD tests |
+| `apps/api/src/scripts/eval.ts` | New — `npm run eval` CLI harness |
+| `apps/api/package.json` | `eval` script |
+| `package.json` | `eval` script passthrough |
+| `docs/eval-report.md` | New — generated methodology report + error analysis, committed as evidence |
+| `docs/eval-report.json` | New — generated JSON summary, committed as evidence, consumed by S8's tile |
+| `docs/plans/caresync-ai/{implementation-plan,issues}.md` | S9 task/AC checkboxes corrected to done |
+| `docs/plans/caresync-ai/{verification-s9,review-s9}.md` | S9 verification + code-review gates recorded |
+
+## Commits
+
+| Commit | Description |
+|--------|-------------|
+| `da61229` | feat(S9): A — eval label file + Seam 4 computeMetrics |
+| `206d924` | feat(S9): B — npm run eval harness + report |
+| `08942c6` | docs(S9): verification-before-completion pass |
+| `73abcce` | fix(S9): export HIGH_RISK_LEVELS instead of duplicating it |
+| `0527d1e` | docs(S9): two-axis code-review artifact (Standards + Spec) |
+
+## Testing & Verification
+
+**How to verify this works:**
+- `docker compose up -d hapi-fhir && npm run fhir:import` (fresh seed)
+- `npm run eval` (repo root) — writes `docs/eval-report.md` + `docs/eval-report.json`
+- `cd apps/api && npx jest --runInBand`
+- `cd apps/web && npx vitest run`
+- `npx tsc --noEmit` in both `apps/api` and `apps/web`
+- `npm run lint --workspace apps/api` / `--workspace apps/web`
+
+**Test results (this session, 2026-07-06, fresh, re-confirmed before finishing):** API **31 suites /
+187 tests passed**, web unit **19 files / 177 tests passed** (S9 makes no frontend change; run as a
+regression check only), both `tsc --noEmit` exit 0, both lint clean (0 errors; 13 pre-existing api
+warnings + 6 pre-existing web warnings, none in S9 files, matching prior slices' baselines). No E2E
+run — S9 has no screen or user-facing-behavior change (backend script + committed data files only), so
+this repo's own `frontend-e2e-verification` trigger doesn't apply.
+
+## Notes
+
+- **Three plan-prose-vs-reality corrections, all caught before/during implementation, not after**: no
+  real Synthea data exists (procedural generator substitution, S5 precedent); no reusable "run + validate"
+  function existed to reuse (the harness replicates `routes/analysis.ts`'s validation glue rather than
+  scoring raw agent output); S8's actual eval-tile contract is looser than the plan's prose implied (only
+  the file path + an optional `headline` string are load-bearing). All three documented in
+  `verification-s9.md` §0/§3.
+- **One Standards-review finding, fixed within this branch**: `errorAnalysis.ts` had duplicated
+  `computeMetrics.ts`'s `HIGH_RISK_LEVELS` constant instead of importing it — fixed in `73abcce`.
+- **Evidence strength:** local mock / packaged script — Jest suites plus one real `npm run eval` run
+  against a local Docker HAPI container with live LLM calls. Not target-environment or client-accepted.
+  The eval's own headline numbers are against **dev-labeled, not clinician-validated** ground truth
+  (GD8) and should not be read as a clinical accuracy claim.
+- **Branch is local-only as of this changelog** — PR not yet opened.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "npm run test:e2e --workspace apps/web",
     "fhir:up": "docker compose up -d hapi-fhir",
     "fhir:import": "npm run import --workspace apps/api",
+    "eval": "npm run eval --workspace apps/api",
     "migrate": "npm run migrate --workspace apps/api",
     "seed": "npm run seed --workspace apps/api"
   }


### PR DESCRIPTION
## Summary
- Adds `npm run eval` (`apps/api/src/scripts/eval.ts`): scores the four agents (Care Gap, Risk, SDOH, Action Planner) against a committed, dev-labeled ground-truth set (`data/eval/labels.json` — 6 curated + 10 procedural patients, GD8) through a pure Seam 4 `computeMetrics` (sensitivity/specificity/PPV, agreement rate) plus a pure `computeErrorAnalysis` for the report's mandatory error-analysis section.
- Produces `docs/eval-report.md` (methodology + error analysis) and `docs/eval-report.json` at the exact path S8's governance eval tile already reads — closing that tile's placeholder for the first time.
- Ships as an honest **dev-labeled ~P6 4** baseline (not clinician-validated), with a clinician-override slot on every label row.
- Real live run: 16/16 labeled patients scored, 0 failures. A genuine finding surfaced: Risk agent specificity is low (30.8%, 9 false positives) against the dev-labeled threshold — disclosed in the report, not smoothed over.

Full detail: `docs/plans/caresync-ai/{implementation-plan.md Iteration 9, verification-s9.md, review-s9.md}` and `docs/superpowers/specs/feature-caresync-s9-eval-harness/2026-07-06-changelog.md`.

## Test plan
- [x] `cd apps/api && npx jest --runInBand` — 31 suites / 187 tests passed
- [x] `cd apps/web && npx vitest run` — 19 files / 177 tests passed (regression check; no frontend change in this PR)
- [x] `npx tsc --noEmit` clean in both `apps/api` and `apps/web`
- [x] `npm run lint` clean in both workspaces (0 errors, pre-existing warnings only)
- [x] `npm run eval` run for real against local Docker HAPI + live LLM calls, artifacts committed as evidence
- [x] Cross-slice check: `getEvalSummary()` called live against the real DB + generated file, confirmed `{available: true, summary: {headline: "..."}}`
- [x] Two-axis code review (Standards + Spec) — one Standards fix applied (deduplicated `HIGH_RISK_LEVELS`), Spec axis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)