### PR TITLE
fix(alerts): honest demo-fallback, working acknowledge, expiry-aware auth

### DIFF
--- a/apps/web/e2e/alerts-auth-fallback.spec.ts
+++ b/apps/web/e2e/alerts-auth-fallback.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+// Regression coverage for the S12 alerts auth/fallback fixes:
+//   1. Acknowledge actually works (was a ReferenceError: setAlerts undefined).
+//   2. DemoFallbackBadge names the real failure (network vs other), instead of
+//      always saying "server unreachable".
+//   3. An expired-but-well-formed token redirects to /login instead of
+//      stranding the user on a protected page behind the demo badge.
+
+async function loginAsCoordinator(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('coordinator@caresync.demo');
+  await page.getByLabel('Password').fill('Demo1234!');
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL(/\/panel|\/tasks|\/population/);
+}
+
+test.describe('Clinical Alerts — auth & demo-fallback (S12)', () => {
+  test('Acknowledge marks an alert acknowledged and drops it from the unacked list', async ({ page }) => {
+    await loginAsCoordinator(page);
+    // Force the deterministic MOCK_ALERTS set (6 unacked) so the count is
+    // stable — this still drives the real acknowledge() handler on real DOM.
+    await page.route('**/api/alerts', (route) => route.abort('failed'));
+    await page.goto('/alerts');
+
+    const ackButtons = page.getByRole('button', { name: 'Acknowledge', exact: true });
+    await expect(ackButtons).toHaveCount(6);
+
+    await ackButtons.first().click();
+
+    // Default view hides acknowledged alerts, so exactly one Acknowledge
+    // button should disappear — proving state updated (no thrown handler).
+    await expect(ackButtons).toHaveCount(5);
+  });
+
+  test('network failure → badge says "server unreachable"', async ({ page }) => {
+    await loginAsCoordinator(page);
+    await page.route('**/api/alerts', (route) => route.abort('failed'));
+
+    await page.goto('/alerts');
+    const badge = page.getByTestId('demo-fallback-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('server unreachable');
+    await expect(page).toHaveURL(/\/alerts/); // authed → stays put, no redirect
+  });
+
+  test('HTTP 500 → badge says "data unavailable" (not "server unreachable")', async ({ page }) => {
+    await loginAsCoordinator(page);
+    await page.route('**/api/alerts', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'boom' }) })
+    );
+
+    await page.goto('/alerts');
+    const badge = page.getByTestId('demo-fallback-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText('data unavailable');
+  });
+
+  test('expired token redirects to /login instead of showing the demo badge', async ({ page }) => {
+    await page.addInitScript(() => {
+      const past = Math.floor(Date.now() / 1000) - 3600; // 1h ago
+      const payload = { id: 'demo-user', role: 'coordinator', name: 'Expired', exp: past };
+      const b64 = btoa(JSON.stringify(payload));
+      localStorage.setItem('caresync_token', `eyJhbGciOiJIUzI1NiJ9.${b64}.sig`);
+    });
+
+    await page.goto('/alerts');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByTestId('demo-fallback-badge')).toHaveCount(0);
+  });
+});

--- a/apps/web/src/auth/useAuth.tsx
+++ b/apps/web/src/auth/useAuth.tsx
@@ -25,6 +25,12 @@ function decodeUser(token: string): AuthUser | null {
     const [, payloadB64] = token.split('.');
     const payload = JSON.parse(atob(payloadB64));
     if (!payload.id || !payload.role) return null;
+    // Reject expired tokens (`exp` is seconds since epoch, per the API's
+    // `signToken`). Without this, an expired-but-well-formed JWT counts as
+    // "logged in" until a request happens to 401 — the user sits on a
+    // protected page showing the demo-fallback badge instead of being sent
+    // to /login. Tokens with no `exp` claim are left alone (backward-compat).
+    if (typeof payload.exp === 'number' && payload.exp * 1000 <= Date.now()) return null;
     return { id: payload.id, name: payload.name, role: payload.role };
   } catch {
     return null;

--- a/apps/web/src/pages/AlertsPage.tsx
+++ b/apps/web/src/pages/AlertsPage.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { getAlerts, type AlertEntry } from '../api/client';
 import { DemoFallbackBadge } from '../components/DemoFallbackBadge';
 
-type Severity = AlertSeverity;
+type Severity = AlertEntry['severity'];
 type AlertCategory = AlertEntry['category'];
 
 const MOCK_ALERTS: AlertEntry[] = [
@@ -94,27 +94,53 @@ async function fetchAlerts(): Promise<AlertEntry[]> {
   return getAlerts();
 }
 
+/**
+ * Honest reason for the demo-fallback badge. A 401 never reaches here (it
+ * clears auth and redirects to /login), so the remaining failure modes are a
+ * network-level failure (API down/restarting — `fetch` throws before a
+ * response) versus any other HTTP error surfaced by `apiFetch` as
+ * "Request failed: <status>". Naming the difference keeps the badge from
+ * claiming "server unreachable" when the server actually answered.
+ */
+function fallbackReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  if (/failed to fetch|networkerror|load failed/i.test(message)) return 'server unreachable';
+  return 'data unavailable';
+}
+
 export default function AlertsPage() {
   const navigate = useNavigate();
   // Real implementation is primary. `MOCK_ALERTS` is a SAFETY NET only —
   // kicks in when the API errors AND we have no real data, surfaced via
   // the `DemoFallbackBadge`. Same pattern as TaskQueue.tsx.
-  const { data, isLoading, isError } = useQuery({
+  const { data, isError, error } = useQuery({
     queryKey: ['alerts'],
     queryFn: fetchAlerts,
     retry: 1,
   });
   const isUsingFallback = isError;
-  const alerts: AlertEntry[] = isError ? MOCK_ALERTS : (data ?? []);
   const [categoryFilter, setCategoryFilter] = useState<AlertCategory | 'all'>('all');
   const [showAcknowledged, setShowAcknowledged] = useState(false);
+  // Acknowledgement is local-only (no write endpoint yet): track the IDs the
+  // user has acked this session and overlay them onto whatever list is live —
+  // real query data or the MOCK_ALERTS safety net.
+  const [acknowledgedIds, setAcknowledgedIds] = useState<Set<string>>(() => new Set());
+
+  const baseAlerts: AlertEntry[] = isError ? MOCK_ALERTS : (data ?? []);
+  const alerts: AlertEntry[] = baseAlerts.map((a) =>
+    acknowledgedIds.has(a.id) ? { ...a, acknowledged: true } : a
+  );
 
   function acknowledge(id: string) {
-    setAlerts((prev) => prev.map((a) => (a.id === id ? { ...a, acknowledged: true } : a)));
+    setAcknowledgedIds((prev) => new Set(prev).add(id));
   }
 
   function acknowledgeAll() {
-    setAlerts((prev) => prev.map((a) => ({ ...a, acknowledged: true })));
+    setAcknowledgedIds((prev) => {
+      const next = new Set(prev);
+      alerts.forEach((a) => next.add(a.id));
+      return next;
+    });
   }
 
   const filtered = alerts.filter((a) => {
@@ -139,7 +165,7 @@ export default function AlertsPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          {isUsingFallback && <DemoFallbackBadge />}
+          {isUsingFallback && <DemoFallbackBadge reason={fallbackReason(error)} />}
           {unackCount > 0 && !isUsingFallback && (
             <button
               onClick={acknowledgeAll}


### PR DESCRIPTION
## Why

The **Clinical Alerts** screen surfaced a "Demo data — server unreachable" badge. Investigation (headless-browser repros) showed the badge itself is working as designed — an authenticated user whose `/api/alerts` call fails at the *network* level (API restarting) correctly falls back to mock data — but it surfaced real defects and rough edges introduced during the s12 lead-merge.

**There is no "401 strands you on the badge" bug** — a 401 already redirects to `/login` correctly. That was verified, not assumed.

## What changed

1. **AlertsPage defects** (`apps/web/src/pages/AlertsPage.tsx`)
   - `type Severity = AlertSeverity` referenced an unimported type → **typecheck failure**. Now `AlertEntry['severity']`.
   - `acknowledge`/`acknowledgeAll` called an undefined `setAlerts` → **Acknowledge buttons threw at runtime**. Now a local `acknowledgedIds` overlay on live/mock data — Acknowledge & Acknowledge all work.
2. **Honest badge label** — `DemoFallbackBadge` reason is derived from the query error: `server unreachable` for network failures, `data unavailable` otherwise (e.g. a 500), instead of always claiming "server unreachable".
3. **Expiry-aware auth** (`apps/web/src/auth/useAuth.tsx`) — `decodeUser` now rejects JWTs whose `exp` has passed, so a stale session drops to `/login` proactively instead of sitting on a protected page behind the demo badge.

## Verification

Evidence strength: **local mock / packaged UI** (headless Playwright against local dev server — not target-environment/client-accepted).

- New `apps/web/e2e/alerts-auth-fallback.spec.ts` — **4/4 pass**: acknowledge decrements the unacked list, network→`server unreachable`, 500→`data unavailable`, expired-token→`/login`.
- `tsc -b` clean · `oxlint` clean (pre-existing warnings only) · **264/264** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)