### PR TITLE
feat(S12): PatientDetail Panel view + real→MOCK fallback + role gating

### DIFF
--- a/apps/api/src/routes/analysis.ts
+++ b/apps/api/src/routes/analysis.ts
@@ -1,11 +1,12 @@
 import { Router, Response } from 'express';
 import Database from 'better-sqlite3';
 import { requireAuth } from '../middleware/auth';
-import { FhirReadService, PatientBundle, ScopeDeniedError } from '../fhir/client';
+import { FhirReadService, PatientBundle, ScopeDeniedError, FhirNotFoundError } from '../fhir/client';
 import { orchestrate } from '../agents/orchestrator';
 import { AgentEvent, AgentId } from '../agents/agent';
 import { validateCitations, validateCitationList, createNarrationBuffer, NarrationBuffer, AgentFlag } from '../agents/citationValidator';
 import { readAnalysisCache, writeAnalysisCache, AnalysisCacheEntry, AnalysisCacheRow } from '../db/analysisCache';
+import { getMockAnalysis } from './mockAnalysis';
 import { writeAudit } from '../db/audit';
 // All four agent modules currently export the same MODEL constant
 // ('gpt-5.5') — riskAgent's is used here as the single source of truth for
@@ -45,17 +46,21 @@ export function writeSseEvent(res: Response, event: string, data: unknown): void
 export interface AnalysisResultJson {
   risk: {
     narration: string;
-    findings: AgentFlag[];
+    // Findings carry agent-specific extras (severity, confidence, finding
+    // text) that are forwarded verbatim to the SSE event payload. The wire
+    // shape is permissive — extras show up in the web's `AnalysisFinding`
+    // via its `[key: string]: unknown` index signature.
+    findings: (AgentFlag & { finding?: string; severity?: string; confidence?: number })[];
     complete: { riskScore: number; riskLevel: string; readmissionProbability: number; findingCount: number; droppedCount: number };
   };
   careGap: {
     narration: string;
-    findings: { gapType: string; description: string; lastDone?: string; dueDate?: string; urgency: string; fhirResourceId: string }[];
+    findings: { gapType: string; description: string; lastDone?: string; dueDate?: string; urgency: string; fhirResourceId: string; severity?: string; confidence?: number }[];
     complete: { findingCount: number; droppedCount: number };
   };
   sdoh: {
     narration: string;
-    findings: { domain: string; finding: string; severity: string; fhirResourceId: string }[];
+    findings: { domain: string; finding: string; severity: string; fhirResourceId: string; confidence?: number }[];
     complete: { findingCount: number; droppedCount: number; referralsNeeded: string[] };
   };
   actionPlanner: {
@@ -220,6 +225,25 @@ export function createAnalysisRouter(
     } catch (err) {
       if (err instanceof ScopeDeniedError) {
         res.status(403).json({ error: err.message });
+        return;
+      }
+      // HAPI 404 — patient id isn't in the FHIR store. Two demo-friendly paths:
+      //   (a) a MOCK-fixture patient id (e.g. `maria-chen-4829`) has a canned
+      //       analysis we can replay so the UI shows the full analysis flow.
+      //   (b) genuinely unknown id → clean JSON 404 (no HTML stack trace).
+      if (err instanceof FhirNotFoundError) {
+        const mock = getMockAnalysis(patientId);
+        if (mock) {
+          res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+          });
+          replayCachedAnalysis(res, mock);
+          res.end();
+          return;
+        }
+        res.status(404).json({ error: 'Patient not found', patientId });
         return;
       }
       throw err;

--- a/apps/api/src/routes/mockAnalysis.ts
+++ b/apps/api/src/routes/mockAnalysis.ts
@@ -1,0 +1,64 @@
+/**
+ * S12 follow-up — Demo fallback for `POST /api/patients/:id/analysis` when
+ * the patient id isn't seeded in HAPI FHIR.
+ *
+ * For demo continuity, the UI ships with `MOCK_PATIENTS` / `MOCK_ANALYSIS`
+ * fixtures (PatientDetail.fixtures.ts in the web app) so unknown routes like
+ * `/patients/maria-chen-4829` still render. Without this fallback, clicking
+ * "Run Analysis" on such a route would 404 — breaking the demo for any URL
+ * pointing at the hero patient.
+ *
+ * This module ports the web's `maria-chen-4829` demo analysis into the
+ * `AnalysisResultJson` shape the API's `replayCachedAnalysis` already
+ * consumes, so the same SSE event sequence a real run emits is what the
+ * client sees. New patient ids should be added to `MOCK_ANALYSIS_JSON` here
+ * (not the web) so the API is the single source of truth for replay data.
+ */
+import type { AnalysisResultJson } from './analysis';
+
+const MOCK_ANALYSIS_JSON: Record<string, AnalysisResultJson> = {
+  'maria-chen-4829': {
+    risk: {
+      narration:
+        'Maria Chen shows very high 30-day readmission risk driven by a recent heart-failure hospitalization, active CHF with elevated BNP, suboptimal diabetes control (HbA1c 8.9%), reduced kidney function, and recurrent moderate depression. Major social needs — housing instability and food insecurity — compound these clinical risks.',
+      findings: [
+        { text: 'HbA1c 8.9% exceeds target — elevated readmission risk', finding: 'HbA1c 8.9% exceeds target — elevated readmission risk', fhirResourceId: 'Observation/obs-hba1c-4829', severity: 'critical', confidence: 0.91 },
+        { text: 'Missing ACE inhibitor despite CHF diagnosis', finding: 'Missing ACE inhibitor despite CHF diagnosis', fhirResourceId: 'Condition/chf-4829', severity: 'high', confidence: 0.87 },
+      ],
+      complete: { riskScore: 87, riskLevel: 'critical', readmissionProbability: 0.7, findingCount: 2, droppedCount: 0 },
+    },
+    careGap: {
+      narration:
+        'Maria is overdue for an annual diabetic eye exam by 14 months and lacks a documented seasonal flu vaccine. Both gaps are within the 30-day outreach window.',
+      findings: [
+        { gapType: 'screening_overdue', description: 'Annual diabetic eye exam overdue by 14 months', urgency: 'high', fhirResourceId: 'CarePlan/cp-4829', severity: 'high', confidence: 0.95 },
+        { gapType: 'immunization_missing', description: 'Flu vaccine not documented this season', urgency: 'medium', fhirResourceId: 'Immunization/imm-4829', severity: 'medium', confidence: 0.88 },
+      ],
+      complete: { findingCount: 2, droppedCount: 0 },
+    },
+    sdoh: {
+      narration:
+        'AHC-HRSN screening flagged transportation and food insecurity as major adherence barriers. Maria lives alone and reports both domains as "often true".',
+      findings: [
+        { domain: 'transportation', finding: 'Transportation barrier to appointments — lives alone', severity: 'high', fhirResourceId: 'QuestionnaireResponse/ahc-4829', confidence: 0.94 },
+        { domain: 'food_security', finding: 'Food insecurity: "often true" — affects medication adherence', severity: 'high', fhirResourceId: 'QuestionnaireResponse/ahc-4829', confidence: 0.89 },
+      ],
+      complete: { findingCount: 2, droppedCount: 0, referralsNeeded: ['Meals on Wheels', 'Transportation assistance'] },
+    },
+    actionPlanner: {
+      narration: 'Synthesizing the risk, care-gap, and SDOH findings into a prioritized action plan.',
+      tasks: [
+        { id: 'mock-act-1', reference: 'Task/mock-act-1', title: 'Schedule 48h post-discharge follow-up call TODAY', description: 'Cardiology follow-up within 72h — BNP elevation at 420 pg/mL', priority: 'critical', assignTo: 'coordinator', dueInDays: 0, fhirResources: ['Encounter/enc-discharge-4829'] },
+        { id: 'mock-act-2', reference: 'Task/mock-act-2', title: 'Refer to Meals on Wheels', description: 'Food insecurity + transportation gap — coordinate community resources', priority: 'high', domain: 'sdoh', assignTo: 'social_worker', dueInDays: 3, fhirResources: ['QuestionnaireResponse/ahc-4829'] },
+        { id: 'mock-act-3', reference: 'Task/mock-act-3', title: 'Coordinate diabetic eye exam referral', description: 'Annual diabetic eye exam overdue by 14 months', priority: 'high', assignTo: 'coordinator', dueInDays: 30, fhirResources: ['CarePlan/cp-4829'] },
+      ],
+      complete: { findingCount: 3, droppedCount: 0 },
+    },
+  },
+};
+
+/** Returns the demo analysis for a patient id, or null if no demo exists.
+ *  Used as a final fallback in the analysis route when HAPI 404s. */
+export function getMockAnalysis(patientId: string): AnalysisResultJson | null {
+  return MOCK_ANALYSIS_JSON[patientId] ?? null;
+}

--- a/apps/api/src/routes/patients.ts
+++ b/apps/api/src/routes/patients.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth';
-import { FhirReadService, ScopeDeniedError } from '../fhir/client';
+import { FhirReadService, ScopeDeniedError, FhirNotFoundError } from '../fhir/client';
 
 export function createPatientsRouter(fhirService: FhirReadService): Router {
   const router = Router();
@@ -22,6 +22,14 @@ export function createPatientsRouter(fhirService: FhirReadService): Router {
     } catch (err) {
       if (err instanceof ScopeDeniedError) {
         res.status(403).json({ error: err.message });
+        return;
+      }
+      // S12 follow-up — HAPI returns 404 for unknown patient ids (e.g. a
+      // demo route like `/patients/maria-chen-4829` that exists only in the
+      // MOCK fixtures). Return a clean JSON 404 so the UI's `buildDisplayPatient`
+      // MOCK-fallback path runs instead of Express's default HTML error page.
+      if (err instanceof FhirNotFoundError) {
+        res.status(404).json({ error: 'Patient not found', patientId: req.params.id });
         return;
       }
       throw err;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
           </RoleGuard>
         }
       >
-        <Route path="/panel" element={<RoleGuard role="coordinator"><PatientPanel /></RoleGuard>} />
+        <Route path="/panel" element={<RoleGuard role="director"><PatientPanel /></RoleGuard>} />
         <Route path="/patients/:id" element={<PatientDetail />} />
         <Route path="/patients/:id/profile" element={<PatientProfile />} />
         <Route path="/patients/:id/sdoh" element={<Sdoh />} />

--- a/apps/web/src/auth/RoleGuard.test.tsx
+++ b/apps/web/src/auth/RoleGuard.test.tsx
@@ -48,8 +48,10 @@ describe('roleHome', () => {
     expect(roleHome('director')).toBe('/population');
   });
 
-  it('sends coordinator to the My Patient Panel', () => {
-    expect(roleHome('coordinator')).toBe('/panel');
+  it('sends coordinator to the Task Center (S12 — was /panel)', () => {
+    // S12 follow-up: /panel is now the director's My Patients list;
+    // coordinators land on /task-center (W13 Task Management).
+    expect(roleHome('coordinator')).toBe('/task-center');
   });
 
   it('sends social_worker to the mobile task queue (M02)', () => {
@@ -62,7 +64,7 @@ function renderPopulationGuard() {
     <MemoryRouter initialEntries={['/population']}>
       <AuthProvider>
         <Routes>
-          <Route path="/panel" element={<div>Coordinator Panel</div>} />
+          <Route path="/task-center" element={<div>Coordinator Task Center</div>} />
           <Route
             path="/population"
             element={
@@ -96,7 +98,7 @@ describe('RoleGuard role restriction', () => {
   it('redirects a coordinator away from a director-only route to their own home', () => {
     setAuthedUser('coordinator');
     renderPopulationGuard();
-    expect(screen.getByText('Coordinator Panel')).toBeInTheDocument();
+    expect(screen.getByText('Coordinator Task Center')).toBeInTheDocument();
     expect(screen.queryByText('Population Dashboard')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/useAuth.tsx
+++ b/apps/web/src/auth/useAuth.tsx
@@ -81,7 +81,10 @@ export function useAuth(): AuthContextValue {
 
 export function roleHome(role: Role): string {
   if (role === 'director') return '/population';
-  if (role === 'coordinator') return '/panel';
+  // S12 follow-up — `/panel` is the director's "My Patients" list now
+  // (was the coordinator's). Coordinators land on the Task Center
+  // (the W13 page ported from the lead) instead.
+  if (role === 'coordinator') return '/task-center';
   // S7 B1 — the Social Worker's mobile task queue (M02) now exists;
   // '/coming-soon' was always a placeholder for this exact screen.
   return '/tasks';

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -153,12 +153,24 @@ describe('AppShell — Sidebar navigation', () => {
     expect(screen.getByTitle('Population')).toBeInTheDocument();
   });
 
-  it('shows a Patients nav button for all roles', () => {
-    localStorage.setItem('caresync_token', tokenFor('coordinator'));
+  it('shows a Patients nav button only for the director (S12 — was all roles)', () => {
+    // S12 follow-up: `/panel` is now the director's My Patients list.
+    // Coordinators land on /task-center instead, so the sidebar Patients
+    // link is director-only.
+    localStorage.setItem('caresync_token', tokenFor('director'));
     const queryClient = new QueryClient();
 
     renderShell(queryClient);
 
     expect(screen.getByTitle('Patients')).toBeInTheDocument();
+  });
+
+  it('hides the Patients nav button for a coordinator', () => {
+    localStorage.setItem('caresync_token', tokenFor('coordinator'));
+    const queryClient = new QueryClient();
+
+    renderShell(queryClient);
+
+    expect(screen.queryByTitle('Patients')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -68,7 +68,7 @@ const LogoutIcon = () => (
 
 const navItems: NavItem[] = [
   { icon: <GridIcon />, label: 'Population', path: '/population', roles: ['director'] },
-  { icon: <PersonIcon />, label: 'Patients', path: '/panel', roles: ['coordinator', 'director'] },
+  { icon: <PersonIcon />, label: 'Patients', path: '/panel', roles: ['director'] },
   { icon: <BarChartIcon />, label: 'Quality', path: '/quality', roles: ['director'] },
   { icon: <ShieldIcon />, label: 'Governance', path: '/governance', roles: ['director'] },
   { icon: <DollarIcon />, label: 'Cost/ROI', path: '/cost-roi' },

--- a/apps/web/src/pages/PatientDetail.tsx
+++ b/apps/web/src/pages/PatientDetail.tsx
@@ -14,7 +14,6 @@ import {
 } from '../api/client';
 import { ageSexLabel, sexLabel } from '../lib/patient';
 import { useAnalysisGraph } from '../lib/analysisGraph';
-import { AgentGraph } from '../components/AgentGraph';
 import {
   MOCK_PATIENTS,
   DEFAULT_VITALS,
@@ -410,6 +409,130 @@ function ActionCard({ action, isCreated, onCreated }: ActionCardProps) {
         onClick={handleCreate}
         disabled={isCreated || loading}
         data-testid={`create-task-${action.citation}`}
+        className={`text-xs px-3 py-1 rounded border transition-colors ${
+          isCreated
+            ? 'bg-emerald-dim text-emerald border-emerald cursor-default'
+            : 'bg-surface-hover border border-border-light text-text-muted hover:border-cyan hover:text-cyan'
+        }`}
+      >
+        {isCreated ? 'Task Created ✓' : loading ? 'Creating…' : 'Create Task'}
+      </button>
+    </div>
+  );
+}
+
+// ── Panel-view sub-components (3-column layout, ported from lead) ───────────
+
+/** Lead's `AgentCard` adapted to the current project's `AgentFeedState`. Renders
+ *  the running-stream text and the complete-state findings list with severity
+ *  dots + FHIR citation + confidence. The status pill ("Complete — N findings"
+ *  / "Running" / "Idle") reuses the existing `statusLabel` helper. */
+function PanelAgentCard({ agentId, feed }: { agentId: AgentId; feed: AgentFeedState }) {
+  const status = statusLabel(feed);
+  const label =
+    status === 'complete'
+      ? `Complete — ${feed.findings.length} finding${feed.findings.length !== 1 ? 's' : ''}`
+      : status === 'running'
+        ? 'Running…'
+        : 'Idle';
+
+  return (
+    <div className="bg-surface-raised rounded-lg p-4 mb-3">
+      <div className="flex items-center gap-2 mb-2">
+        <StatusDot status={status} />
+        <span className="font-bold text-text text-sm">{AGENT_LABELS[agentId]}</span>
+        <span className="ml-auto text-text-dim text-xs">{label}</span>
+      </div>
+
+      {status === 'running' && feed.text && (
+        <p className="text-text-muted text-xs font-mono mt-1 leading-relaxed line-clamp-3">
+          {feed.text}
+        </p>
+      )}
+
+      {status === 'complete' && feed.findings.length > 0 && (
+        <ul className="mt-2 space-y-2">
+          {feed.findings.map((f, i) => {
+            const sev = coerceSeverity(f.severity ?? 'medium');
+            const text = f.text ?? f.finding ?? f.description ?? 'Untitled finding';
+            const conf = typeof f.confidence === 'number' ? f.confidence : null;
+            return (
+              <li key={`${f.fhirResourceId ?? 'finding'}-${i}`} className="flex gap-2 items-start">
+                <span className={`mt-1 flex-shrink-0 w-2 h-2 rounded-full ${severityDot(sev)}`} />
+                <div className="min-w-0">
+                  <p className="text-text text-sm leading-snug">{text}</p>
+                  <div className="flex items-center gap-3 mt-0.5">
+                    <span className="text-text-dim text-xs font-mono truncate">{f.fhirResourceId ?? 'unsourced'}</span>
+                    {conf !== null && (
+                      <span className="text-text-dim text-xs flex-shrink-0">Conf: {conf.toFixed(2)}</span>
+                    )}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {feed.summary && (
+        <div className="mt-2 pt-2 border-t border-border text-[11px] text-text-muted">
+          <span data-testid={SUMMARY_TESTID[agentId]}>
+            {agentId === 'risk'
+              ? `${feed.summary.riskLevel ?? 'unknown'} risk · score ${feed.summary.riskScore ?? '—'}`
+              : `${feed.summary.findingCount} findings · ${feed.summary.droppedCount} dropped`}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Lead's `ActionCard` adapted to the current project's `DisplayAction` shape.
+ *  Severity pill + finding body + FHIR citation + confidence bar + "Create
+ *  Task" stub button. Same local-only creation affordance as CinemaView's
+ *  ActionCard — real Task resources are created by the actionPlanner's stream
+ *  `task` event handler in `handleRunAnalysis`. */
+function PanelActionCard({ action, isCreated, onCreated }: {
+  action: DisplayAction;
+  isCreated: boolean;
+  onCreated: (key: string) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const handleCreate = async () => {
+    if (isCreated || loading) return;
+    setLoading(true);
+    try {
+      await new Promise((r) => setTimeout(r, 250));
+    } finally {
+      onCreated(action.key);
+      setLoading(false);
+    }
+  };
+  return (
+    <div className="bg-surface-raised rounded-lg p-4 mb-3 border border-border-light">
+      <div className="flex items-center gap-2 mb-2">
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full uppercase tracking-wide ${priorityBadgeClasses(action.severity)}`}>
+          {action.severity}
+        </span>
+      </div>
+      <p className="font-medium text-text text-sm leading-snug mb-1">{action.text}</p>
+      <p className="text-text-dim text-xs font-mono mb-3">{action.citation}</p>
+      <div className="mb-3">
+        <div className="flex justify-between mb-1">
+          <span className="text-text-dim text-xs">Confidence</span>
+          <span className="text-text-dim text-xs">{(action.confidence * 100).toFixed(0)}%</span>
+        </div>
+        <div className="w-full h-1 bg-surface rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full ${confidenceBarColor(action.confidence)}`}
+            style={{ width: `${action.confidence * 100}%` }}
+          />
+        </div>
+      </div>
+      <button
+        onClick={handleCreate}
+        disabled={isCreated || loading}
+        data-testid={`panel-create-task-${action.citation}`}
         className={`text-xs px-3 py-1 rounded border transition-colors ${
           isCreated
             ? 'bg-emerald-dim text-emerald border-emerald cursor-default'
@@ -941,10 +1064,19 @@ export function PatientDetail() {
   const queryClient = useQueryClient();
 
   // Real data fetch (backend pattern).
+  // Don't retry 4xx — a 404 means the patient id isn't in HAPI, retrying
+  // would just delay the UI's fall-through to the MOCK-fixture display path
+  // (and keep the "Loading patient…" message on screen for ~30s while the
+  // library's default 3-retry exponential backoff runs out).
   const { data: patientData, isLoading, isError, error } = useQuery({
     queryKey: ['patient', id],
     queryFn: () => getPatient(id!),
     enabled: !!id,
+    retry: (failureCount, err) => {
+      const msg = (err as Error).message ?? '';
+      if (/not found|404/i.test(msg)) return false;
+      return failureCount < 2;
+    },
   });
 
   // Cross-surface sync (backend pattern): a `task-updated` event for THIS
@@ -969,10 +1101,12 @@ export function PatientDetail() {
   const [lastMode, setLastMode] = useState<'cached' | 'live' | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('panel');
   const [createdActionKeys, setCreatedActionKeys] = useState<Set<string>>(new Set());
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
 
   async function handleRunAnalysis(live: boolean) {
     if (!id || running) return;
     setRunning(true);
+    setAnalysisError(null);
     setLastMode(live ? 'live' : 'cached');
     setFeeds(makeFeeds());
     setCreatedTasks([]);
@@ -1002,6 +1136,14 @@ export function PatientDetail() {
         },
         { live },
       );
+    } catch (err) {
+      // S12 follow-up — stream errors were previously swallowed in the
+      // finally block, leaving the UI in `running=false` with no feedback
+      // (the "Run Analysis" button just stops spinning). Surface the
+      // message inline so the user knows why nothing happened — e.g. the
+      // API returned 404 for a patient id that has no MOCK analysis
+      // fallback.
+      setAnalysisError((err as Error).message);
     } finally {
       setRunning(false);
     }
@@ -1013,6 +1155,20 @@ export function PatientDetail() {
 
   const patient = buildDisplayPatient(patientData, id);
   const actions = buildActionPlan(feeds, createdTasks);
+
+  // Real-implementation risk override: the hero badge reflects the live analysis
+  // (feeds.risk.summary carries riskScore + riskLevel emitted by the backend's
+  // risk agent) once a run completes, so ANY seeded HAPI patient — not just the
+  // MOCK fixtures — gets a meaningful score. Falls back to the MOCK-derived
+  // patient.riskScore/riskLevel only before the first analysis runs.
+  const liveRisk = feeds.risk.summary;
+  const displayRiskScore =
+    typeof liveRisk?.riskScore === 'number' ? liveRisk.riskScore : patient.riskScore;
+  const displayRiskLevel: DisplayPatient['riskLevel'] =
+    liveRisk?.riskLevel === 'critical' || liveRisk?.riskLevel === 'high' ||
+    liveRisk?.riskLevel === 'medium' || liveRisk?.riskLevel === 'low'
+      ? liveRisk.riskLevel
+      : patient.riskLevel;
 
   const ViewToggle = () => (
     <div className="inline-flex items-center bg-surface border border-border rounded-lg p-0.5 text-xs font-medium">
@@ -1092,153 +1248,175 @@ export function PatientDetail() {
     );
   }
 
-  // Panel view (default — the view the existing test suite asserts against) --
+  // Panel view (default — 3-column layout ported from lead project) --------
+  // Render the grid off the `patient` view-model, which is ALWAYS populated
+  // (buildDisplayPatient falls back to MOCK_PATIENTS when the API 404s). This
+  // means the screen renders for every patient — HAPI-seeded, MOCK-only, or
+  // unknown — and the API error is shown inline instead of blocking the UI.
   return (
     <>
-      <div className="flex items-center justify-between">
-        <BackLink />
-        <ViewToggle />
-      </div>
-
       {isLoading && <p className="text-body text-text-muted mt-4">Loading patient…</p>}
-      {isError && <p className="text-body text-red mt-4">{(error as Error).message}</p>}
+      {isError && (
+        <p className="text-body text-amber mt-4" data-testid="patient-fallback-notice">
+          Showing demo data — live record unavailable: {(error as Error).message}
+        </p>
+      )}
 
-      {patientData && (
-        <div className="mt-4">
-          {/* Top bar matches reference-materials/caresync-ai.html's .pt-bar. */}
-          <div className="h-11 flex items-center gap-2.5 px-4 -mx-6 -mt-6 mb-6 border-b border-border bg-surface">
-            <span className="text-section font-bold text-text">{patientData.patient.name}</span>
-            <span className="text-body text-text-muted">{ageSexLabel(patientData.patient.birthDate, patientData.patient.gender)}</span>
-            <span className="font-mono text-xs text-text-dim flex-1 truncate">| Patient/{patientData.patient.id}</span>
-            {lastMode && (
-              <span
-                className="font-mono text-[10px] text-text-dim uppercase tracking-wide"
-                data-testid="analysis-mode"
-                aria-live="polite"
+      {!isLoading && (
+      <div className="grid h-[calc(100vh-48px)] overflow-hidden gap-4 p-4" style={{ gridTemplateColumns: '25% 40% 35%' }}>
+          {/* ── Left column: Patient Profile ───────────────────────────── */}
+          <div className="bg-surface rounded-xl border border-border p-5 overflow-y-auto flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <BackLink />
+              <ViewToggle />
+            </div>
+
+            <p className="text-text-muted text-xs uppercase tracking-wider">Patient Profile</p>
+
+            <div>
+              <h1 className="text-xl font-bold text-text">{patient.name}</h1>
+              <p className="text-text-muted text-sm mt-0.5">
+                {patient.age}y {patient.sex} · MRN {patient.mrn}
+              </p>
+            </div>
+
+            {/* Hero risk badge — driven by live analysis once available, so it
+                reflects the real implementation for any patient, not just the
+                MOCK fixtures in PatientDetail.fixtures.ts. */}
+            <div className="flex justify-center">
+              <div
+                className={`px-6 py-3 rounded-full flex flex-col items-center ${riskBadgeClasses(displayRiskLevel)}`}
+                style={displayRiskLevel === 'critical' ? { boxShadow: '0 0 32px rgba(232,72,72,0.4)' } : undefined}
+                data-testid="panel-risk-badge"
               >
-                {lastMode === 'live' ? 'requested: live' : 'requested: cached'}
-              </span>
-            )}
-            <button
-              onClick={() => handleRunAnalysis(true)}
-              disabled={running}
-              className="flex items-center gap-2 bg-transparent border border-border-light text-text-muted font-mono text-label font-bold tracking-wide px-3 py-1.5 rounded-md disabled:opacity-60 disabled:cursor-default"
-            >
-              Run live
-            </button>
-            <button
-              onClick={() => handleRunAnalysis(false)}
-              disabled={running}
-              className="flex items-center gap-2 bg-cyan-dim border border-cyan text-cyan font-mono text-label font-bold tracking-wide px-4 py-1.5 rounded-md disabled:opacity-85 disabled:cursor-default"
-            >
-              {running ? (
-                <span className="w-3 h-3 rounded-full border-2 border-cyan/25 border-t-cyan animate-spin" aria-hidden="true" />
-              ) : (
-                <svg width="10" height="12" viewBox="0 0 10 12" fill="none" aria-hidden="true">
-                  <path d="M1 1.2v9.6L9 6 1 1.2Z" fill="#00C8FF" />
-                </svg>
-              )}
-              <span>{running ? 'Analyzing…' : 'Run Analysis'}</span>
-            </button>
-          </div>
-
-          {/* Agent graph — live SSE events update node status here. */}
-          <div className="mb-6">
-            <AgentGraph state={graphState} />
-          </div>
-
-          {/* Per-agent feed cards. Each one updates exactly one feed per
-              SSE event — no cross-agent bleed (the bug the lead-port version
-              had via runMockSim's overlapping timeouts). */}
-          <div className="grid grid-cols-4 gap-2.5 mb-6">
-            {AGENT_KEYS.map((agentId) => {
-              const feed = feeds[agentId];
-              return (
-                <div
-                  key={agentId}
-                  className={`bg-surface border border-border ${AGENT_ACCENT[agentId].border} border-l-[3px] rounded-card flex flex-col overflow-hidden min-h-[112px]`}
-                >
-                  <div className={`text-[9.5px] font-bold tracking-wide uppercase px-2.5 pt-2 pb-1 ${AGENT_ACCENT[agentId].text}`}>
-                    {AGENT_LABELS[agentId]}
-                  </div>
-                  <div className="flex-1 px-2.5 pb-2.5 text-xs leading-relaxed overflow-y-auto">
-                    {!feed.started && <span className="italic text-text-dim">Awaiting analysis run…</span>}
-                    {feed.started && (
-                      <>
-                        <span className={feed.summary ? 'text-text' : 'text-text-muted'}>{feed.text}</span>
-                        {feed.findings.length > 0 && (
-                          <div className="mt-1.5 flex flex-wrap gap-1">
-                            {feed.findings.map((flag, i) => (
-                              <span
-                                key={`${flag.fhirResourceId ?? 'finding'}-${i}`}
-                                className="font-mono text-[10px] text-text-dim bg-bg border border-border rounded-chip px-1.5 py-0.5"
-                              >
-                                {flag.fhirResourceId ?? 'unsourced'}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-                        {feed.summary && (
-                          <div className="mt-2 pt-2 border-t border-border text-[11px] text-text-muted">
-                            <span data-testid={SUMMARY_TESTID[agentId]}>
-                              {agentId === 'risk'
-                                ? `${feed.summary.riskLevel} risk · score ${feed.summary.riskScore}`
-                                : `${feed.summary.findingCount} findings · ${feed.summary.droppedCount} dropped`}
-                            </span>
-                          </div>
-                        )}
-                      </>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          <h2 className="text-section text-text mb-2">Active Conditions</h2>
-          <div className="border border-border rounded-card overflow-hidden mb-6">
-            {patientData.conditions.map((condition) => (
-              <div key={condition.id} className="px-4 py-3 border-b border-border last:border-b-0 bg-surface">
-                <p className="text-body text-text">{condition.display}</p>
-                <p className="text-xs font-mono text-text-dim">
-                  ICD-10 {condition.code} · Condition/{condition.id}
-                </p>
-              </div>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-2 mb-2">
-            <h2 className="text-section text-text">Tasks</h2>
-            <span className="text-xs font-bold text-cyan bg-cyan-dim border border-cyan rounded-pill px-2.5 py-0.5">
-              {patientData.tasks.length + createdTasks.length} open
-            </span>
-          </div>
-          {patientData.tasks.length === 0 && createdTasks.length === 0 && (
-            <p className="text-body text-text-muted">No open tasks.</p>
-          )}
-          {[...patientData.tasks.map((t) => ({ key: `existing-${t.id}`, title: t.title, priority: t.priority, due: t.due, status: t.status, ref: `Task/${t.id}` })),
-            ...createdTasks.map((t) => ({ key: `created-${t.id}`, title: t.title, priority: coerceSeverity(t.priority), due: `Due in ${t.dueInDays ?? '—'}d`, status: 'Open', ref: t.reference })),
-          ].map((task) => (
-            <div
-              key={task.key}
-              data-testid={task.key}
-              className="bg-surface-raised border border-border rounded-card p-2.5 mb-2"
-            >
-              <div className="flex items-center justify-between mb-1.5">
-                <span className="text-[9px] font-bold tracking-wide rounded-pill border px-2 py-0.5 bg-surface-raised text-text-muted">
-                  {task.priority}
-                </span>
-                <span className="text-xs text-text-muted">{task.due}</span>
-              </div>
-              <p className="text-body font-bold text-text mb-1.5">{task.title}</p>
-              <div className="flex items-center justify-between">
-                <span className="font-mono text-[10.5px] text-text-dim">{task.ref}</span>
-                <span className="text-xs font-semibold text-text-muted border border-border-light rounded-pill px-2 py-px">
-                  {task.status}
+                <span className="text-3xl font-bold leading-none">{displayRiskScore || '—'}</span>
+                <span className="text-xs font-semibold uppercase tracking-wider mt-1 opacity-80">
+                  {displayRiskLevel} risk
                 </span>
               </div>
             </div>
-          ))}
+
+            {/* Conditions */}
+            <div>
+              <p className="text-text-muted text-xs uppercase tracking-wider mb-2">Conditions</p>
+              <ul className="space-y-1.5">
+                {patient.conditions.map((condition, i) => {
+                  // Mirror lead's conditionDot scheme — assign critical/high/medium/low
+                  // round-robin so the demo shows the colour scale.
+                  const sev: Severity = (['critical', 'high', 'medium', 'low'] as Severity[])[
+                    Math.min(i, 3)
+                  ];
+                  return (
+                    <li key={condition} className="flex items-center gap-2">
+                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${severityDot(sev)}`} />
+                      <span className="text-text text-sm">{condition}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            {/* Key vitals */}
+            <div>
+              <p className="text-text-muted text-xs uppercase tracking-wider mb-2">Key Vitals</p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+                {DEFAULT_VITALS.map((vital) => (
+                  <div key={vital.label}>
+                    <p className="text-text-muted text-xs">{vital.label}</p>
+                    <p className="text-text font-mono text-sm font-medium">{vital.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Last contact */}
+            <div className="mt-auto pt-4 border-t border-border-light">
+              <p className="text-text-muted text-xs">
+                Last contact:{' '}
+                <span
+                  className={`font-medium ${
+                    patient.daysSinceContact <= 3
+                      ? 'text-emerald'
+                      : patient.daysSinceContact <= 14
+                        ? 'text-amber'
+                        : 'text-red'
+                  }`}
+                >
+                  {patient.daysSinceContact}d ago
+                </span>
+              </p>
+            </div>
+          </div>
+
+          {/* ── Middle column: AI Agent Analysis ────────────────────────── */}
+          <div className="bg-surface rounded-xl border border-border p-5 overflow-y-auto flex flex-col">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-text font-semibold text-base">AI Agent Analysis</h2>
+              <div className="flex items-center gap-2">
+                {lastMode && (
+                  <span
+                    className="font-mono text-[10px] text-text-dim uppercase tracking-wide"
+                    data-testid="analysis-mode"
+                    aria-live="polite"
+                  >
+                    {lastMode === 'live' ? 'requested: live' : 'requested: cached'}
+                  </span>
+                )}
+                <button
+                  onClick={() => handleRunAnalysis(true)}
+                  disabled={running}
+                  className="bg-transparent border border-border-light text-text-muted font-mono text-label font-bold tracking-wide px-3 py-1.5 rounded-md disabled:opacity-60 disabled:cursor-default"
+                >
+                  Run live
+                </button>
+                <button
+                  onClick={() => handleRunAnalysis(false)}
+                  disabled={running}
+                  data-testid="panel-run-analysis"
+                  className="bg-violet text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {running ? 'Running…' : 'Run Analysis'}
+                </button>
+              </div>
+            </div>
+
+            <div className="flex-1">
+              {analysisError && (
+                <p className="text-amber text-xs mb-2" data-testid="analysis-error">
+                  Analysis unavailable: {analysisError}
+                </p>
+              )}
+              {AGENT_KEYS.map((agentId) => (
+                <PanelAgentCard key={agentId} agentId={agentId} feed={feeds[agentId]} />
+              ))}
+            </div>
+          </div>
+
+          {/* ── Right column: Action Plan ───────────────────────────────── */}
+          <div className="bg-surface rounded-xl border border-border p-5 overflow-y-auto flex flex-col">
+            <p className="text-text-muted text-xs uppercase tracking-wider mb-4">Action Plan</p>
+
+            {actions.length === 0 ? (
+              <div className="flex-1 flex flex-col items-center justify-center text-center gap-3">
+                <span className="text-4xl">🤖✨</span>
+                <p className="text-text font-medium">No action plan yet</p>
+                <p className="text-text-muted text-sm max-w-xs">
+                  Run analysis to let the AI agents generate a prioritised action plan for this patient.
+                </p>
+              </div>
+            ) : (
+              <div className="flex-1">
+                {actions.map((action) => (
+                  <PanelActionCard
+                    key={action.key}
+                    action={action}
+                    isCreated={createdActionKeys.has(action.key)}
+                    onCreated={handleActionCreated}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Patient screen rebuild
- Port the lead project's 3-column Panel view (left profile, middle agent analysis, right action plan) over the current project's PatientDetail. UI-only — all functional logic (TanStack Query, SSE streamAnalysis, buildDisplayPatient, buildActionPlan) preserved.
- Add PanelAgentCard + PanelActionCard helpers that consume the current project's AgentFeedState + DisplayAction shapes; reuse all existing helpers (severityDot, riskBadgeClasses, etc.).
- Hero risk badge now reflects live analysis (feeds.risk.summary) for any patient, with MOCK_PATIENTS fallback only before the first run.
- Remove the AgentGraph (Orchestrator animated) block from the Panel view middle column to match the lead's Panel layout. OrchestratorView still works behind the "Orchestrator" view toggle.
- Wire analysis errors inline (was silently swallowed in finally).
- Don't retry 4xx on the patient query — keeps the MOCK fallback path snappy instead of waiting ~30s on the library's default 3-retry exponential backoff.

API surface
- patients + analysis routes now return clean JSON 404 (was HTML 500 stack trace) on FhirNotFoundError, so the UI's fallback path runs.
- analysis route additionally falls through to a server-side MOCK_ANALYSIS replay (apps/api/src/routes/mockAnalysis.ts) for known MOCK-fixture patient ids like maria-chen-4829 — so "Run Analysis" works for every patient, demo or real.

Role gating
- /panel route's RoleGuard flipped coordinator → director.
- Sidebar Patients nav item flipped ['coordinator','director'] → ['director'].
- roleHome('coordinator') now /task-center (was /panel).
- Updated AppShell + RoleGuard tests; added "hides the Patients nav button for a coordinator" test.

Tests: web 265/265, api 263/264 (same single pre-existing failure). Verified at UI surface via Playwright (director → /population, /panel, /patients/:id; coordinator → /task-center; MOCK + real + unknown patient flows on /patients/:id).