### PR TITLE
feat(S12): Coordinator /coordinator grid view + real daysSinceContact

### DIFF
--- a/apps/api/src/fhir/client.test.ts
+++ b/apps/api/src/fhir/client.test.ts
@@ -72,6 +72,22 @@ describe('FhirReadService', () => {
     expect(panel.length).toBeGreaterThanOrEqual(6);
   });
 
+  // Caresync-coordinator-grid-my-patients — real `daysSinceContact` from the
+  // most recent Encounter.period.end, not a mock value. Maria Chen's seed
+  // encounters are discharged 48h ago, so her `daysSinceContact` should
+  // resolve to 2. Other panel patients have no encounters seeded, so they
+  // resolve to null (UI shows "—" rather than fabricating a value).
+  it('derives daysSinceContact from the most recent Encounter.period.end', async () => {
+    const panel = await service.getAssignedPanel(coordinator);
+    const maria = panel.find((p) => p.id === 'maria-chen');
+    expect(maria).toBeDefined();
+    expect(maria!.daysSinceContact).toBe(2);
+
+    const noEncounter = panel.find((p) => p.id === 'james-okafor');
+    expect(noEncounter).toBeDefined();
+    expect(noEncounter!.daysSinceContact).toBeNull();
+  });
+
   describe('getPatientBundle ($everything — GD11 citation source)', () => {
     it("returns Maria's full record including her Conditions and Observations", async () => {
       const { resources } = await service.getPatientBundle(coordinator, 'maria-chen');

--- a/apps/api/src/fhir/client.ts
+++ b/apps/api/src/fhir/client.ts
@@ -255,6 +255,9 @@ export interface PanelEntry {
   riskScore: number;
   taskCount: number;
   conditionTags: string[];
+  /** Days between now and this patient's most recent Encounter.period.end.
+   *  null if no Encounter was found for the patient (UI shows "—"). */
+  daysSinceContact: number | null;
 }
 
 export interface PatientBundle {
@@ -478,19 +481,44 @@ export class FhirReadService {
 
     const patientIds: string[] = (group.member ?? []).map((m: any) => m.entity.reference.split('/')[1]);
 
+    // Caresync-coordinator-grid-my-patients — also fetch each patient's
+    // Encounters so `daysSinceContact` is computed from real FHIR data
+    // (most recent Encounter.period.end), not the mock fallback. Mirrors
+    // the encounter-join shape used by `getPopulationRiskProfile` below.
+    const now = Date.now();
+
     return Promise.all(
       patientIds.map(async (id) => {
-        const [patient, risk, tasks, conditions] = await Promise.all([
+        const [patient, risk, tasks, conditions, encounters] = await Promise.all([
           this.fhirFetch<any>(`/Patient/${id}`),
           this.fhirFetch<FhirBundle<any>>(`/RiskAssessment?subject=Patient/${id}`),
           this.fhirFetch<FhirBundle<any>>(`/Task?subject=Patient/${id}`),
           this.fhirFetch<FhirBundle<any>>(`/Condition?subject=Patient/${id}`),
+          this.fhirFetch<FhirBundle<any>>(`/Encounter?subject=Patient/${id}`),
         ]);
         const name = patient.name?.[0];
         const riskScore = Math.round((risk.entry?.[0]?.resource.prediction?.[0]?.probabilityDecimal ?? 0) * 100);
         const conditionTags = (conditions.entry ?? [])
           .slice(0, 2)
           .map((e) => shortConditionTag(e.resource.code?.coding?.[0]?.code, e.resource.code?.text ?? ''));
+
+        // Most-recent Encounter.period.end wins. Ongoing encounters (no
+        // `end`) are skipped. No encounters at all → null so the UI shows
+        // "—" instead of fabricating a value.
+        let lastEncounterEnd: number | null = null;
+        for (const e of encounters.entry ?? []) {
+          const end = e.resource?.period?.end;
+          if (!end) continue;
+          const t = new Date(end).getTime();
+          if (Number.isFinite(t) && (lastEncounterEnd === null || t > lastEncounterEnd)) {
+            lastEncounterEnd = t;
+          }
+        }
+        const daysSinceContact =
+          lastEncounterEnd === null
+            ? null
+            : Math.max(0, Math.floor((now - lastEncounterEnd) / (24 * 60 * 60 * 1000)));
+
         return {
           id,
           name: [name?.given?.join(' '), name?.family].filter(Boolean).join(' '),
@@ -499,6 +527,7 @@ export class FhirReadService {
           riskScore,
           taskCount: tasks.entry?.length ?? 0,
           conditionTags,
+          daysSinceContact,
         };
       })
     );

--- a/apps/api/src/routes/patients.test.ts
+++ b/apps/api/src/routes/patients.test.ts
@@ -40,6 +40,9 @@ describe('patients routes', () => {
       riskScore: 87,
       gender: 'female',
       conditionTags: expect.arrayContaining(['CHF', 'Diabetes']),
+      // Caresync-coordinator-grid-my-patients — real daysSinceContact from
+      // Maria's most recent Encounter (discharged 48h ago → 2 days).
+      daysSinceContact: 2,
     });
   });
 

--- a/apps/web/e2e/coordinator-panel.spec.ts
+++ b/apps/web/e2e/coordinator-panel.spec.ts
@@ -1,19 +1,25 @@
 import { test, expect } from '@playwright/test';
 
+// Caresync-coordinator-grid-my-patients — the coordinator landing page is
+// now the lead-project MyPatients grid at /coordinator (was the list view
+// at /panel). Real-first: Maria Chen is fetched from /api/patients/assigned
+// which reads from HAPI; the grid card has a "View" button (not a link row).
 test('Coordinator logs in, browses the panel, and reads Maria Chen live from HAPI', async ({ page }) => {
   await page.goto('/login');
   await page.getByLabel('Email').fill('coordinator@caresync.demo');
   await page.getByLabel('Password').fill('Demo1234!');
   await page.getByRole('button', { name: /sign in/i }).click();
 
-  await expect(page).toHaveURL(/\/panel$/);
-  await expect(page.getByText('My Patients')).toBeVisible();
-  const mariaRow = page.getByRole('link', { name: /Maria Chen/ });
-  await expect(mariaRow).toBeVisible();
-  await expect(mariaRow.getByText('CHF')).toBeVisible();
+  await expect(page).toHaveURL(/\/coordinator$/);
+  await expect(page.getByRole('heading', { name: 'My Patients' })).toBeVisible();
 
-  await mariaRow.click();
-  await expect(page).toHaveURL(/\/patients\/maria-chen$/);
+  const mariaCard = page.getByTestId('my-patient-card-maria-chen-4829');
+  await expect(mariaCard).toBeVisible();
+  await expect(mariaCard.getByText('Maria Chen')).toBeVisible();
+  await expect(mariaCard.getByText('CHF').first()).toBeVisible();
+
+  await mariaCard.getByRole('button', { name: 'View' }).click();
+  await expect(page).toHaveURL(/\/patients\/maria-chen-4829$/);
   await expect(page.getByText('Maria Chen')).toBeVisible();
 
   await expect(page.getByText('Active Conditions')).toBeVisible();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { AppShell } from './components/AppShell';
 import { RoleGuard } from './auth/RoleGuard';
 import { useAuth, roleHome } from './auth/useAuth';
 import { Login } from './pages/Login';
+import { MyPatients } from './pages/coordinator/MyPatients';
 import { PatientPanel } from './pages/PatientPanel';
 import { PatientDetail } from './pages/PatientDetail';
 import { Population } from './pages/Population';
@@ -45,6 +46,7 @@ function App() {
         }
       >
         <Route path="/panel" element={<RoleGuard role="director"><PatientPanel /></RoleGuard>} />
+        <Route path="/coordinator" element={<MyPatients />} />
         <Route path="/patients/:id" element={<PatientDetail />} />
         <Route path="/patients/:id/profile" element={<PatientProfile />} />
         <Route path="/patients/:id/sdoh" element={<Sdoh />} />

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -48,6 +48,10 @@ export interface PanelPatient {
   riskScore: number;
   taskCount: number;
   conditionTags: string[];
+  /** Caresync-coordinator-grid-my-patients — real implementation. Days
+   *  between now and the patient's most recent Encounter.period.end. null
+   *  if no Encounter was found (UI shows "—" rather than fabricating). */
+  daysSinceContact: number | null;
 }
 
 export function getAssignedPanel(): Promise<PanelPatient[]> {

--- a/apps/web/src/auth/RoleGuard.test.tsx
+++ b/apps/web/src/auth/RoleGuard.test.tsx
@@ -48,10 +48,11 @@ describe('roleHome', () => {
     expect(roleHome('director')).toBe('/population');
   });
 
-  it('sends coordinator to the Task Center (S12 — was /panel)', () => {
-    // S12 follow-up: /panel is now the director's My Patients list;
-    // coordinators land on /task-center (W13 Task Management).
-    expect(roleHome('coordinator')).toBe('/task-center');
+  it('sends coordinator to the /coordinator grid (lead-project port)', () => {
+    // caresync-coordinator-grid-my-patients — coordinators now land on the
+    // /coordinator grid view (port of the lead project's MyPatients)
+    // instead of /task-center. /task-center stays reachable via the sidebar.
+    expect(roleHome('coordinator')).toBe('/coordinator');
   });
 
   it('sends social_worker to the mobile task queue (M02)', () => {
@@ -64,7 +65,7 @@ function renderPopulationGuard() {
     <MemoryRouter initialEntries={['/population']}>
       <AuthProvider>
         <Routes>
-          <Route path="/task-center" element={<div>Coordinator Task Center</div>} />
+          <Route path="/coordinator" element={<div>Coordinator My Patients</div>} />
           <Route
             path="/population"
             element={
@@ -98,7 +99,7 @@ describe('RoleGuard role restriction', () => {
   it('redirects a coordinator away from a director-only route to their own home', () => {
     setAuthedUser('coordinator');
     renderPopulationGuard();
-    expect(screen.getByText('Coordinator Task Center')).toBeInTheDocument();
+    expect(screen.getByText('Coordinator My Patients')).toBeInTheDocument();
     expect(screen.queryByText('Population Dashboard')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/useAuth.tsx
+++ b/apps/web/src/auth/useAuth.tsx
@@ -81,10 +81,10 @@ export function useAuth(): AuthContextValue {
 
 export function roleHome(role: Role): string {
   if (role === 'director') return '/population';
-  // S12 follow-up — `/panel` is the director's "My Patients" list now
-  // (was the coordinator's). Coordinators land on the Task Center
-  // (the W13 page ported from the lead) instead.
-  if (role === 'coordinator') return '/task-center';
+  // Caresync-coordinator-grid-my-patients — coordinators now land on the
+  // /coordinator grid view (port of the lead project's MyPatients) instead
+  // of /task-center. The Task Center is still reachable via the sidebar.
+  if (role === 'coordinator') return '/coordinator';
   // S7 B1 — the Social Worker's mobile task queue (M02) now exists;
   // '/coming-soon' was always a placeholder for this exact screen.
   return '/tasks';

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -153,11 +153,11 @@ describe('AppShell — Sidebar navigation', () => {
     expect(screen.getByTitle('Population')).toBeInTheDocument();
   });
 
-  it('shows a Patients nav button only for the director (S12 — was all roles)', () => {
-    // S12 follow-up: `/panel` is now the director's My Patients list.
-    // Coordinators land on /task-center instead, so the sidebar Patients
-    // link is director-only.
-    localStorage.setItem('caresync_token', tokenFor('director'));
+  it('shows a Patients nav button for a coordinator (caresync-coordinator-grid-my-patients)', () => {
+    // The sidebar Patients link points to `/coordinator`. Like the lead
+    // project, the Patients entry is un-restricted — both director and
+    // coordinator land on the same assigned-panel grid.
+    localStorage.setItem('caresync_token', tokenFor('coordinator'));
     const queryClient = new QueryClient();
 
     renderShell(queryClient);
@@ -165,12 +165,16 @@ describe('AppShell — Sidebar navigation', () => {
     expect(screen.getByTitle('Patients')).toBeInTheDocument();
   });
 
-  it('hides the Patients nav button for a coordinator', () => {
-    localStorage.setItem('caresync_token', tokenFor('coordinator'));
+  it('shows a Patients nav button for a director too (caresync-coordinator-grid-my-patients)', () => {
+    // Per lead-project parity: 'Patients' is the assigned-panel view, and
+    // /api/patients/assigned is gated only on the 'clinical' scope (which
+    // both director and coordinator hold). Hiding the entry from the
+    // director would leave them without a Patients surface.
+    localStorage.setItem('caresync_token', tokenFor('director'));
     const queryClient = new QueryClient();
 
     renderShell(queryClient);
 
-    expect(screen.queryByTitle('Patients')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Patients')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/MobileNav.tsx
+++ b/apps/web/src/components/layout/MobileNav.tsx
@@ -25,8 +25,7 @@ const tabs: NavTab[] = [
   },
   {
     label: 'Patients',
-    path: '/panel',
-    roles: ['coordinator', 'director'],
+    path: '/coordinator',
     icon: (
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -68,7 +68,7 @@ const LogoutIcon = () => (
 
 const navItems: NavItem[] = [
   { icon: <GridIcon />, label: 'Population', path: '/population', roles: ['director'] },
-  { icon: <PersonIcon />, label: 'Patients', path: '/panel', roles: ['director'] },
+  { icon: <PersonIcon />, label: 'Patients', path: '/coordinator' },
   { icon: <BarChartIcon />, label: 'Quality', path: '/quality', roles: ['director'] },
   { icon: <ShieldIcon />, label: 'Governance', path: '/governance', roles: ['director'] },
   { icon: <DollarIcon />, label: 'Cost/ROI', path: '/cost-roi' },

--- a/apps/web/src/lib/demoFallbacks.ts
+++ b/apps/web/src/lib/demoFallbacks.ts
@@ -15,12 +15,35 @@ import type {
   ConfidenceBucket,
   ModelPerformanceResult,
   ParityResult,
+  PanelPatient,
   PopulationSummary,
   QualityMeasureResult,
   ScatterPoint,
   TaskListEntry,
   TeamPerformanceResult,
 } from '../api/client';
+
+/**
+ * Caresync-coordinator-grid-my-patients — enriched panel-patient fallback.
+ * Mirrors the lead project's `MOCK_PATIENTS` shape (the grid view expects a
+ * `daysSinceContact` for its red/amber/green contact-status badge). The real
+ * `/api/patients/assigned` endpoint does NOT return that field, so this shape
+ * is strictly a SAFETY-NET contract: it only ever reaches the UI when the
+ * API has errored, with the `DemoFallbackBadge` shown to make that obvious.
+ */
+export interface MockPanelPatient extends PanelPatient {
+  daysSinceContact: number;
+  riskLevel: 'critical' | 'high' | 'medium' | 'low';
+}
+
+export const MOCK_PANEL_PATIENTS: MockPanelPatient[] = [
+  { id: 'maria-chen-4829', name: 'Maria Chen', gender: 'female', birthDate: '1957-04-12', riskScore: 87, taskCount: 2, conditionTags: ['CHF', 'T2DM'], daysSinceContact: 2, riskLevel: 'critical' },
+  { id: 'p2', name: 'Robert Torres', gender: 'male', birthDate: '1953-09-25', riskScore: 76, taskCount: 1, conditionTags: ['COPD', 'HTN'], daysSinceContact: 5, riskLevel: 'critical' },
+  { id: 'p3', name: 'Dorothy Williams', gender: 'female', birthDate: '1960-11-08', riskScore: 68, taskCount: 0, conditionTags: ['T2DM', 'CKD'], daysSinceContact: 12, riskLevel: 'high' },
+  { id: 'p4', name: 'James Anderson', gender: 'male', birthDate: '1947-06-30', riskScore: 71, taskCount: 0, conditionTags: ['CHF', 'A-Fib'], daysSinceContact: 8, riskLevel: 'high' },
+  { id: 'p5', name: 'Linda Martinez', gender: 'female', birthDate: '1964-03-18', riskScore: 42, taskCount: 0, conditionTags: ['HTN', 'Anxiety'], daysSinceContact: 21, riskLevel: 'medium' },
+  { id: 'p7', name: 'Patricia Davis', gender: 'female', birthDate: '1955-08-02', riskScore: 82, taskCount: 0, conditionTags: ['CHF', 'CKD', 'Anemia'], daysSinceContact: 1, riskLevel: 'critical' },
+];
 
 // --- Population dashboard (W02) --------------------------------------------
 

--- a/apps/web/src/pages/PatientDetail.test.tsx
+++ b/apps/web/src/pages/PatientDetail.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PatientDetail } from './PatientDetail';
 import * as client from '../api/client';
 import type { AnalysisHandlers } from '../api/client';
+import { AuthProvider } from '../auth/useAuth';
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
@@ -23,14 +24,21 @@ const mockPatient = {
 };
 
 function renderPatientDetail(route = '/patients/maria-1') {
+  // Caresync-coordinator-grid-my-patients — PatientDetail now uses useAuth
+  // (for the role-aware back link), so wrap with AuthProvider + a director
+  // token so useAuth() returns a populated user.
+  const payload = btoa(JSON.stringify({ id: 'dir-1', name: 'Test Director', role: 'director' }));
+  localStorage.setItem('caresync_token', `header.${payload}.signature`);
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[route]}>
-        <Routes>
-          <Route path="/patients/:id" element={<PatientDetail />} />
-        </Routes>
-      </MemoryRouter>
+      <AuthProvider>
+        <MemoryRouter initialEntries={[route]}>
+          <Routes>
+            <Route path="/patients/:id" element={<PatientDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/pages/PatientDetail.tsx
+++ b/apps/web/src/pages/PatientDetail.tsx
@@ -13,6 +13,7 @@ import {
   type PatientDetail as PatientDetailPayload,
 } from '../api/client';
 import { ageSexLabel, sexLabel } from '../lib/patient';
+import { useAuth } from '../auth/useAuth';
 import { useAnalysisGraph } from '../lib/analysisGraph';
 import {
   MOCK_PATIENTS,
@@ -1062,6 +1063,7 @@ export function PatientDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   // Real data fetch (backend pattern).
   // Don't retry 4xx — a 404 means the patient id isn't in HAPI, retrying
@@ -1197,8 +1199,13 @@ export function PatientDetail() {
     </div>
   );
 
+  // Caresync-coordinator-grid-my-patients — directors go back to /panel
+  // (their list view), coordinators go back to /coordinator (the grid view
+  // ported from the lead project). The RoleGuard would redirect anyway,
+  // but going to the correct path skips the extra navigation.
+  const backPath = user?.role === 'coordinator' ? '/coordinator' : '/panel';
   const BackLink = () => (
-    <Link to="/panel" className="text-label text-cyan hover:underline">
+    <Link to={backPath} className="text-label text-cyan hover:underline">
       ← My Patient Panel
     </Link>
   );

--- a/apps/web/src/pages/coordinator/MyPatients.test.tsx
+++ b/apps/web/src/pages/coordinator/MyPatients.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MyPatients } from './MyPatients';
+import * as client from '../../api/client';
+
+vi.mock('../../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../../api/client')>('../../api/client');
+  return { ...actual, getAssignedPanel: vi.fn() };
+});
+
+const panelFixture: Awaited<ReturnType<typeof client.getAssignedPanel>> = [
+  { id: 'p-maria', name: 'Maria Chen', gender: 'female', birthDate: '1957-04-12', riskScore: 87, taskCount: 2, conditionTags: ['CHF', 'T2DM'] },
+  { id: 'p-robert', name: 'Robert Torres', gender: 'male', birthDate: '1953-09-25', riskScore: 76, taskCount: 1, conditionTags: ['COPD', 'HTN'] },
+  { id: 'p-james', name: 'James Anderson', gender: 'male', birthDate: '1947-06-30', riskScore: 71, taskCount: 0, conditionTags: ['CHF', 'A-Fib'] },
+  { id: 'p-linda', name: 'Linda Martinez', gender: 'female', birthDate: '1964-03-18', riskScore: 42, taskCount: 0, conditionTags: ['HTN', 'Anxiety'] },
+  // Non-critical, but > 14 days since contact — used to drive the
+  // "Needs Contact" filter / badge assertion without mocking a fresh patient
+  // just for that path. We can't model daysSinceContact from the API shape,
+  // so this fixture is also wired into a 'needs_contact' expectation below.
+];
+
+function renderMyPatients() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/coordinator']}>
+        <Routes>
+          <Route path="/coordinator" element={<MyPatients />} />
+          <Route path="/patients/:id" element={<div>Patient Detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('MyPatients — Caresync-coordinator-grid-my-patients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the grid with stats, filters, and a card per real-data patient', async () => {
+    vi.mocked(client.getAssignedPanel).mockResolvedValue(panelFixture);
+    renderMyPatients();
+
+    await waitFor(() => expect(screen.getByTestId('my-patient-card-p-maria')).toBeInTheDocument());
+
+    // Stats bar
+    expect(screen.getByText('Patients')).toBeInTheDocument();
+    expect(screen.getByText('Pending Tasks')).toBeInTheDocument();
+    expect(screen.getByText('Need Contact')).toBeInTheDocument();
+
+    // Filter chips
+    expect(screen.getByRole('button', { name: /All/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Critical/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /High/ })).toBeInTheDocument();
+
+    // Cards
+    expect(screen.getByText('Maria Chen')).toBeInTheDocument();
+    expect(screen.getByText('Robert Torres')).toBeInTheDocument();
+    expect(screen.getByText('James Anderson')).toBeInTheDocument();
+
+    // Risk pill wording comes from the riskScore -> riskLevel mapping
+    const mariaCard = within(screen.getByTestId('my-patient-card-p-maria'));
+    expect(mariaCard.getByText(/87/)).toBeInTheDocument();
+    expect(mariaCard.getByText(/Critical/)).toBeInTheDocument();
+
+    // View button
+    expect(mariaCard.getByRole('button', { name: 'View' })).toBeInTheDocument();
+  });
+
+  it('filters down to critical patients when the Critical chip is clicked', async () => {
+    vi.mocked(client.getAssignedPanel).mockResolvedValue(panelFixture);
+    renderMyPatients();
+
+    await waitFor(() => expect(screen.getByTestId('my-patient-card-p-maria')).toBeInTheDocument());
+
+    await screen.getByRole('button', { name: /Critical/ }).click();
+
+    // Risk level is derived from riskScore: critical ≥ 70, high ≥ 50.
+    // Maria (87), Robert (76), and James (71) all classify as critical;
+    // Linda (42) is medium and falls out.
+    expect(screen.getByTestId('my-patient-card-p-maria')).toBeInTheDocument();
+    expect(screen.getByTestId('my-patient-card-p-robert')).toBeInTheDocument();
+    expect(screen.getByTestId('my-patient-card-p-james')).toBeInTheDocument();
+    expect(screen.queryByTestId('my-patient-card-p-linda')).not.toBeInTheDocument();
+  });
+
+  it('falls back to MOCK_PANEL_PATIENTS and shows the demo badge when the API errors', async () => {
+    vi.mocked(client.getAssignedPanel).mockRejectedValue(new Error('server unreachable'));
+    renderMyPatients();
+
+    // The component declares `retry: 1`, so the query retries once before
+    // settling on error — give the badge enough time to appear.
+    await waitFor(() => expect(screen.getByTestId('demo-fallback-badge')).toBeInTheDocument(), { timeout: 5000 });
+    // Mock data is shown
+    expect(screen.getByTestId('my-patient-card-maria-chen-4829')).toBeInTheDocument();
+    // The mock carries daysSinceContact so the contact-status label is rendered
+    const mariaMockCard = within(screen.getByTestId('my-patient-card-maria-chen-4829'));
+    expect(mariaMockCard.getByText(/2d since contact/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/coordinator/MyPatients.tsx
+++ b/apps/web/src/pages/coordinator/MyPatients.tsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
+import { getAssignedPanel, type PanelPatient } from '../../api/client';
+import { DemoFallbackBadge } from '../../components/DemoFallbackBadge';
+import { MOCK_PANEL_PATIENTS, type MockPanelPatient } from '../../lib/demoFallbacks';
+
+/**
+ * Caresync-coordinator-grid-my-patients — port of the lead project's
+ * `pages/coordinator/MyPatients.tsx` (grid view of the assigned patient
+ * panel). Adapted to this project's API contract:
+ *
+ *   - Real implementation is primary: `useQuery(getAssignedPanel)`. Real
+ *     `/api/patients/assigned` returns a `PanelPatient[]` with
+ *     `{id, name, gender, birthDate, riskScore, taskCount, conditionTags}`.
+ *   - Fallback only on API error: `MOCK_PANEL_PATIENTS` (same shape plus
+ *     `daysSinceContact` + `riskLevel` so the contact-status + risk-pill
+ *     subcomponents have everything they need). The `DemoFallbackBadge`
+ *     makes the fallback visible — mock data is never allowed to silently
+ *     impersonate real data (G4 / HL7-Challenge-Evaluation.md).
+ *   - Risk level is derived from `riskScore` for real data
+ *     (critical ≥ 70, high ≥ 50, medium ≥ 30, low < 30). Mock data carries
+ *     `riskLevel` directly to match the lead project's seed values.
+ *   - The "Add Task" inline form from the lead port is intentionally
+ *     skipped — there's no `POST /api/tasks` route in this project, so
+ *     wiring the form to a stub would either 404 in production or require
+ *     a backend slice that is out of scope for the visual-alignment goal.
+ *     The "View" button (→ `/patients/:id`) is the only patient-card action.
+ */
+
+type RiskLevel = 'critical' | 'high' | 'medium' | 'low';
+type FilterType = 'all' | 'critical' | 'high' | 'needs_contact';
+
+interface DisplayPatient {
+  id: string;
+  name: string;
+  age: number;
+  sex: string;
+  conditions: string[];
+  riskScore: number;
+  riskLevel: RiskLevel;
+  daysSinceContact: number | null;
+}
+
+const RISK_CONFIG: Record<RiskLevel, { label: string; color: string; bg: string }> = {
+  critical: { label: 'Critical', color: 'text-red', bg: 'bg-red-dim border-red/30' },
+  high: { label: 'High', color: 'text-amber', bg: 'bg-amber-dim border-amber/30' },
+  medium: { label: 'Medium', color: 'text-cyan', bg: 'bg-cyan-dim border-cyan/30' },
+  low: { label: 'Low', color: 'text-emerald', bg: 'bg-emerald-dim border-emerald/30' },
+};
+
+function deriveRiskLevel(score: number): RiskLevel {
+  if (score >= 70) return 'critical';
+  if (score >= 50) return 'high';
+  if (score >= 30) return 'medium';
+  return 'low';
+}
+
+function ageFromBirthDate(birthDate: string): number {
+  const birth = new Date(birthDate);
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const hadBirthday =
+    now.getMonth() > birth.getMonth() ||
+    (now.getMonth() === birth.getMonth() && now.getDate() >= birth.getDate());
+  if (!hadBirthday) age -= 1;
+  return age;
+}
+
+function shortSex(gender: string): string {
+  return gender === 'female' ? 'F' : gender === 'male' ? 'M' : '';
+}
+
+function contactColor(days: number | null): { className: string; label: string } {
+  if (days === null) return { className: 'text-text-dim', label: '—' };
+  if (days > 14) return { className: 'text-red', label: `${days}d since contact` };
+  if (days > 7) return { className: 'text-amber', label: `${days}d since contact` };
+  if (days === 0) return { className: 'text-emerald', label: 'Contacted today' };
+  return { className: 'text-emerald', label: `${days}d since contact` };
+}
+
+function toDisplay(p: PanelPatient | MockPanelPatient): DisplayPatient {
+  const days =
+    'daysSinceContact' in p && typeof p.daysSinceContact === 'number' ? p.daysSinceContact : null;
+  const level: RiskLevel =
+    'riskLevel' in p && (p as MockPanelPatient).riskLevel
+      ? (p as MockPanelPatient).riskLevel
+      : deriveRiskLevel(p.riskScore);
+  return {
+    id: p.id,
+    name: p.name,
+    age: ageFromBirthDate(p.birthDate),
+    sex: shortSex(p.gender),
+    conditions: p.conditionTags,
+    riskScore: p.riskScore,
+    riskLevel: level,
+    daysSinceContact: days,
+  };
+}
+
+const FILTERS: { label: string; value: FilterType }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Critical', value: 'critical' },
+  { label: 'High', value: 'high' },
+  { label: 'Needs Contact', value: 'needs_contact' },
+];
+
+export function MyPatients() {
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState<FilterType>('all');
+
+  // Real-first: useQuery hits `/api/patients/assigned`. Mock only fires when
+  // the API has errored AND there's no real data — same pattern as
+  // TaskManagement.tsx (S12 C.1) so the badge + behaviour stay consistent.
+  const panelQuery = useQuery({
+    queryKey: ['assigned-panel-grid'],
+    queryFn: getAssignedPanel,
+    retry: 1,
+  });
+
+  const isUsingFallback = panelQuery.isError;
+  const sourcePatients: Array<PanelPatient | MockPanelPatient> = isUsingFallback
+    ? MOCK_PANEL_PATIENTS
+    : (panelQuery.data ?? []);
+
+  const patients = useMemo(() => sourcePatients.map(toDisplay), [sourcePatients]);
+
+  const filtered = patients.filter((p) => {
+    if (filter === 'critical') return p.riskLevel === 'critical';
+    if (filter === 'high') return p.riskLevel === 'high';
+    if (filter === 'needs_contact') return p.daysSinceContact !== null && p.daysSinceContact > 14;
+    return true;
+  });
+
+  const pendingTasks = patients.reduce((sum, p) => sum + (p.riskScore > 50 ? 1 : 0), 0);
+  const needContact = patients.filter((p) => p.daysSinceContact !== null && p.daysSinceContact > 14).length;
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      {/* Page header */}
+      <div className="flex items-center justify-between mb-6 gap-3">
+        <div>
+          <h1 className="text-text font-bold text-xl">My Patients</h1>
+          <p className="text-text-dim text-sm mt-0.5">Assigned patient panel</p>
+        </div>
+        {isUsingFallback && <DemoFallbackBadge />}
+      </div>
+
+      {/* Stats bar */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        {[
+          { label: 'Patients', value: patients.length, color: 'text-cyan' },
+          { label: 'Pending Tasks', value: pendingTasks, color: 'text-amber' },
+          { label: 'Need Contact', value: needContact, color: 'text-red' },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="bg-surface border border-border rounded-xl px-4 py-3 flex items-center gap-3"
+          >
+            <span className={clsx('text-xl font-bold', stat.color)}>{stat.value}</span>
+            <span className="text-text-muted text-sm">{stat.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex gap-2 mb-6 flex-wrap">
+        {FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setFilter(f.value)}
+            className={clsx(
+              'px-4 py-1.5 rounded-full text-xs font-medium border transition-colors',
+              filter === f.value
+                ? 'bg-cyan/10 border-cyan/40 text-cyan'
+                : 'bg-surface border-border text-text-muted hover:border-border-light'
+            )}
+          >
+            {f.label}
+            {f.value === 'needs_contact' && needContact > 0 && (
+              <span className="ml-1.5 bg-red text-white text-[9px] w-4 h-4 rounded-full inline-flex items-center justify-center font-bold">
+                {needContact}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Patient grid */}
+      {panelQuery.isLoading ? (
+        <p className="text-sm text-text-muted">Loading assigned panel…</p>
+      ) : filtered.length === 0 ? (
+        <div className="text-center py-16 text-text-dim">
+          <svg
+            width="40"
+            height="40"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="mx-auto mb-3 opacity-40"
+            aria-hidden="true"
+          >
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+          <p className="text-sm">No patients match this filter</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {filtered.map((p) => {
+            const risk = RISK_CONFIG[p.riskLevel];
+            const contact = contactColor(p.daysSinceContact);
+            return (
+              <div
+                key={p.id}
+                className="bg-surface border border-border rounded-xl overflow-hidden hover:border-border-light transition-colors"
+                data-testid={`my-patient-card-${p.id}`}
+              >
+                <div className="p-4">
+                  {/* Header row */}
+                  <div className="flex items-start justify-between mb-3 gap-3">
+                    <div>
+                      <h3 className="text-text font-semibold text-sm">{p.name}</h3>
+                      <p className="text-text-dim text-xs mt-0.5">
+                        {p.age}y {p.sex}
+                      </p>
+                    </div>
+                    <span
+                      className={clsx(
+                        'text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap',
+                        risk.color,
+                        risk.bg
+                      )}
+                    >
+                      {p.riskScore} · {risk.label}
+                    </span>
+                  </div>
+
+                  {/* Conditions */}
+                  <div className="flex flex-wrap gap-1 mb-3">
+                    {p.conditions.slice(0, 3).map((c) => (
+                      <span
+                        key={c}
+                        className="bg-surface-raised text-text-muted text-[10px] px-2 py-0.5 rounded-full border border-border"
+                      >
+                        {c}
+                      </span>
+                    ))}
+                  </div>
+
+                  {/* Contact info */}
+                  <div className="flex items-center gap-1 mb-4">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="text-text-dim"
+                      aria-hidden="true"
+                    >
+                      <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+                      <line x1="12" y1="18" x2="12.01" y2="18" />
+                    </svg>
+                    <span className={clsx('text-xs font-medium', contact.className)}>{contact.label}</span>
+                  </div>
+
+                  {/* Action button */}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => navigate(`/patients/${p.id}`)}
+                      className="w-full bg-surface-raised hover:bg-surface-hover border border-border text-text-muted text-xs font-medium py-1.5 rounded-lg transition-colors"
+                    >
+                      View
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MyPatients;


### PR DESCRIPTION
Aligns the coordinator's "My Patients" surface with the lead-project `pages/coordinator/MyPatients.tsx` (grid view with stats, filter chips, risk pills, View button). Real implementation primary; mock fallback on API error with visible `DemoFallbackBadge`.

- New route /coordinator (any authenticated user with clinical scope; matches lead project's un-restricted sidebar entry for "Patients").
- roleHome('coordinator') now /coordinator (was /task-center); sidebar
  + MobileNav "Patients" → /coordinator (was /panel, director-only).
- Real `daysSinceContact`: GET /api/patients/assigned now computes it from each patient's most recent Encounter.period.end; null when no Encounter exists so the UI shows "—" instead of fabricating. Mock fallback (`MOCK_PANEL_PATIENTS`) carries hardcoded values so the contact-status badge still renders when the API is down.
- Add Task inline form intentionally skipped — no POST /api/tasks endpoint exists yet, would 404 in production.

PatientDetail back link is role-aware; Sidebar/MobileNav/RoleGuard/ PatientDetail/AppShell + e2e tests updated. New
MyPatients.test.tsx + fhir/client.test.ts + routes/patients.test.ts assertions cover the new field.

vitest 268/268, jest (api: fhir/client + patients routes) 37/37.