### PR TITLE
fix(build): add daysSinceContact to test fixture; drop unused Patient…

### DIFF
--- a/apps/web/src/pages/PatientDetail.tsx
+++ b/apps/web/src/pages/PatientDetail.tsx
@@ -12,7 +12,7 @@ import {
   type AssignedTaskEvent,
   type PatientDetail as PatientDetailPayload,
 } from '../api/client';
-import { ageSexLabel, sexLabel } from '../lib/patient';
+import { sexLabel } from '../lib/patient';
 import { useAuth } from '../auth/useAuth';
 import { useAnalysisGraph } from '../lib/analysisGraph';
 import {
@@ -1099,7 +1099,7 @@ export function PatientDetail() {
   const [running, setRunning] = useState(false);
   const [feeds, setFeeds] = useState<Record<AgentId, AgentFeedState>>(() => makeFeeds());
   const [createdTasks, setCreatedTasks] = useState<AnalysisTask[]>([]);
-  const [graphState, dispatchGraph] = useAnalysisGraph();
+  const [, dispatchGraph] = useAnalysisGraph();
   const [lastMode, setLastMode] = useState<'cached' | 'live' | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('panel');
   const [createdActionKeys, setCreatedActionKeys] = useState<Set<string>>(new Set());

--- a/apps/web/src/pages/coordinator/MyPatients.test.tsx
+++ b/apps/web/src/pages/coordinator/MyPatients.test.tsx
@@ -11,14 +11,14 @@ vi.mock('../../api/client', async () => {
 });
 
 const panelFixture: Awaited<ReturnType<typeof client.getAssignedPanel>> = [
-  { id: 'p-maria', name: 'Maria Chen', gender: 'female', birthDate: '1957-04-12', riskScore: 87, taskCount: 2, conditionTags: ['CHF', 'T2DM'] },
-  { id: 'p-robert', name: 'Robert Torres', gender: 'male', birthDate: '1953-09-25', riskScore: 76, taskCount: 1, conditionTags: ['COPD', 'HTN'] },
-  { id: 'p-james', name: 'James Anderson', gender: 'male', birthDate: '1947-06-30', riskScore: 71, taskCount: 0, conditionTags: ['CHF', 'A-Fib'] },
-  { id: 'p-linda', name: 'Linda Martinez', gender: 'female', birthDate: '1964-03-18', riskScore: 42, taskCount: 0, conditionTags: ['HTN', 'Anxiety'] },
+  { id: 'p-maria', name: 'Maria Chen', gender: 'female', birthDate: '1957-04-12', riskScore: 87, taskCount: 2, conditionTags: ['CHF', 'T2DM'], daysSinceContact: 2 },
+  { id: 'p-robert', name: 'Robert Torres', gender: 'male', birthDate: '1953-09-25', riskScore: 76, taskCount: 1, conditionTags: ['COPD', 'HTN'], daysSinceContact: 5 },
+  { id: 'p-james', name: 'James Anderson', gender: 'male', birthDate: '1947-06-30', riskScore: 71, taskCount: 0, conditionTags: ['CHF', 'A-Fib'], daysSinceContact: 8 },
   // Non-critical, but > 14 days since contact — used to drive the
   // "Needs Contact" filter / badge assertion without mocking a fresh patient
-  // just for that path. We can't model daysSinceContact from the API shape,
-  // so this fixture is also wired into a 'needs_contact' expectation below.
+  // just for that path. daysSinceContact comes from the API shape now, so
+  // this fixture is also wired into a 'needs_contact' expectation below.
+  { id: 'p-linda', name: 'Linda Martinez', gender: 'female', birthDate: '1964-03-18', riskScore: 42, taskCount: 0, conditionTags: ['HTN', 'Anxiety'], daysSinceContact: 21 },
 ];
 
 function renderMyPatients() {


### PR DESCRIPTION
…Detail symbols

Build errors blocking `npm run build --workspace apps/api && npm run build --workspace apps/web`:

- MyPatients.test.tsx: PanelPatient (client.ts:54) requires daysSinceContact, but the test's panelFixture omitted it → 4x TS2741. Added per-row values matching the MOCK_PANEL_PATIENTS baseline (Maria 2, Robert 5, James 8, Linda 21) and updated the stale comment that claimed the API shape couldn't model it.

- PatientDetail.tsx:15 — unused import `ageSexLabel` → TS6133.
- PatientDetail.tsx:1102 — unused destructured `graphState` (only dispatchGraph is used) → TS6133.